### PR TITLE
Further Heppy bugfixes

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/core/TriggerBitAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/core/TriggerBitAnalyzer.py
@@ -1,5 +1,4 @@
 import ROOT
-from ROOT.heppy import TriggerBitChecker
 
 from PhysicsTools.Heppy.analyzers.core.Analyzer import Analyzer
 from PhysicsTools.Heppy.analyzers.core.AutoHandle import AutoHandle
@@ -26,7 +25,7 @@ class TriggerBitAnalyzer( Analyzer ):
                 if not hasattr(setup ,"globalVariables") :
                         setup.globalVariables = []
                 setup.globalVariables.append( NTupleVariable(outname, eval("lambda ev: ev.%s" % outname), help="OR of %s"%TL) )
-                self.triggerBitCheckers.append( (T, TriggerBitChecker(trigVec)) )
+                self.triggerBitCheckers.append( (T, ROOT.heppy.TriggerBitChecker(trigVec)) )
 
     def process(self, event):
         self.readCollections( event.input )

--- a/PhysicsTools/Heppy/python/analyzers/core/TriggerBitFilter.py
+++ b/PhysicsTools/Heppy/python/analyzers/core/TriggerBitFilter.py
@@ -1,5 +1,4 @@
 import ROOT
-from ROOT.heppy import TriggerBitChecker
 
 from PhysicsTools.Heppy.analyzers.core.Analyzer import Analyzer
 from PhysicsTools.Heppy.analyzers.core.AutoHandle import AutoHandle
@@ -13,11 +12,11 @@ class TriggerBitFilter( Analyzer ):
         vetoTriggers = cfg_comp.vetoTriggers if hasattr(cfg_comp, 'vetoTriggers') else []
         trigVec = ROOT.vector(ROOT.string)()
         for t in triggers: trigVec.push_back(t)
-        self.mainFilter = TriggerBitChecker(trigVec)
+        self.mainFilter = ROOT.heppy.TriggerBitChecker(trigVec)
         if len(vetoTriggers):
             vetoVec = ROOT.vector(ROOT.string)()
             for t in vetoTriggers: vetoVec.push_back(t)
-            self.vetoFilter = TriggerBitChecker(vetoVec)
+            self.vetoFilter = ROOT.heppy.TriggerBitChecker(vetoVec)
         else:
             self.vetoFilter = None 
         

--- a/PhysicsTools/Heppy/python/analyzers/objects/all.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/all.py
@@ -1,4 +1,3 @@
-from PhysicsTools.Heppy.analyzers.objects.GeneratorAnalyzer import GeneratorAnalyzer
 from PhysicsTools.Heppy.analyzers.objects.JetAnalyzer import JetAnalyzer
 from PhysicsTools.Heppy.analyzers.objects.LeptonAnalyzer import LeptonAnalyzer
 from PhysicsTools.Heppy.analyzers.objects.METAnalyzer import METAnalyzer

--- a/PhysicsTools/HeppyCore/python/framework/heppy.py
+++ b/PhysicsTools/HeppyCore/python/framework/heppy.py
@@ -29,9 +29,14 @@ def callBack( result ):
     pass
     print 'production done:', str(result)
 
-def runLoopAsync(comp, outDir, config, options):
-    loop = runLoop( comp, outDir, config, options)
-    return loop.name
+def runLoopAsync(comp, outDir, configName, options):
+    try:
+        loop = runLoop( comp, outDir, copy.copy(sys.modules[configName].config), options)
+        return loop.name
+    except Exception:
+        import traceback
+        print traceback.format_exc()
+        raise
 
 def runLoop( comp, outDir, config, options):
     fullName = '/'.join( [outDir, comp.name ] )
@@ -123,7 +128,7 @@ def main( options, args ):
         sys.exit(3)
 
     file = open( cfgFileName, 'r' )
-    cfg = imp.load_source( 'cfg', cfgFileName, file)
+    cfg = imp.load_source( 'PhysicsTools.HeppyCore.__cfg_to_run__', cfgFileName, file)
 
     selComps = [comp for comp in cfg.config.components if len(comp.files)>0]
     selComps = split(selComps)
@@ -141,7 +146,7 @@ def main( options, args ):
         import PhysicsTools.HeppyCore.framework.heppy as ML 
         for comp in selComps:
             print 'submitting', comp.name
-            pool.apply_async( ML.runLoopAsync, [comp, outDir, cfg.config, options],
+            pool.apply_async( ML.runLoopAsync, [comp, outDir, 'PhysicsTools.HeppyCore.__cfg_to_run__', options],
                               callback=ML.callBack)
         pool.close()
         pool.join()

--- a/PhysicsTools/HeppyCore/python/framework/heppy.py
+++ b/PhysicsTools/HeppyCore/python/framework/heppy.py
@@ -35,6 +35,9 @@ def runLoopAsync(comp, outDir, configName, options):
         return loop.name
     except Exception:
         import traceback
+        print "ERROR processing component %s" % comp.name
+        print comp
+        print "STACK TRACE: "
         print traceback.format_exc()
         raise
 


### PR DESCRIPTION
Some bugfixes that didn't show up until things were cleaned up also from CMGTools side and more testing was done:
- `heppy` did not work multithread when using the `AutoFillTreeProducer` since the config is not pickleable (re-importing didn't work, as the cfg can modify sequences or objects, and when running with `multiprocessing`  the modification was being done twice)
- also, get stack traces when running within `multiprocess'
- `from ROOT.heppy import TriggerBitChecker` doesn't seem to work anymore after cleaning up `CMGTools.RootTools` from my working area (no idea why) but `ROOT.heppy.TriggerBitChecker` works
- `GeneratorAnalyzer` was by mistake also in `objects.all` and not only in `gen.all`

@arizzi @mariadalfonso
