### PR TITLE
Possibility to use TFileService file in TreeProducers and one simple fix in JetAnalyzer

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/core/AutoFillTreeProducer.py
+++ b/PhysicsTools/Heppy/python/analyzers/core/AutoFillTreeProducer.py
@@ -20,8 +20,6 @@ class AutoFillTreeProducer( TreeAnalyzerNumpy ):
         if not getattr(self.cfg_ana, 'saveTLorentzVectors', False):
             fourVectorType.removeVariable("p4")
 
-        ## Declare how we store floats by default
-        self.tree.setDefaultFloatType("F"); # otherwise it's "D"
  
         self.collections = {}      
         self.globalObjects = {}
@@ -32,6 +30,11 @@ class AutoFillTreeProducer( TreeAnalyzerNumpy ):
                 self.globalObjects=cfg_ana.globalObjects
         if hasattr(cfg_ana,"globalVariables"):
                 self.globalVariables=cfg_ana.globalVariables
+
+    def beginLoop(self, setup) :
+        super(AutoFillTreeProducer, self).beginLoop(setup)
+        ## Declare how we store floats by default
+        self.tree.setDefaultFloatType("F"); # otherwise it's "D"
 
     def declareHandles(self):
         super(AutoFillTreeProducer, self).declareHandles()

--- a/PhysicsTools/Heppy/python/analyzers/core/TreeAnalyzerNumpy.py
+++ b/PhysicsTools/Heppy/python/analyzers/core/TreeAnalyzerNumpy.py
@@ -11,17 +11,22 @@ class TreeAnalyzerNumpy( Analyzer ):
 
     def __init__(self, cfg_ana, cfg_comp, looperName):
         super(TreeAnalyzerNumpy,self).__init__(cfg_ana, cfg_comp, looperName)
-        fileName = '/'.join([self.dirName,
-                             'tree.root'])
 
-        isCompressed = self.cfg_ana.isCompressed if hasattr(cfg_ana,'isCompressed') else 1
-        print 'Compression', isCompressed
 
-        self.file = TFile( fileName, 'recreate', '', isCompressed )
-        self.tree = Tree('tree', self.name)
 
     def beginLoop(self, setup) :
         super(TreeAnalyzerNumpy, self).beginLoop(setup)
+        print setup.services
+        if "outputfile" in setup.services:
+            print "Using outputfile given in setup.outputfile"
+            self.file = setup.services["outputfile"].file
+        else :
+            fileName = '/'.join([self.dirName,
+                             'tree.root'])
+            isCompressed = self.cfg_ana.isCompressed if hasattr(self.cfg_ana,'isCompressed') else 1
+            print 'Compression', isCompressed
+            self.file = TFile( fileName, 'recreate', '', isCompressed )
+        self.tree = Tree('tree', self.name)
         self.declareVariables(setup)
         
     def declareVariables(self,setup):
@@ -30,5 +35,6 @@ class TreeAnalyzerNumpy( Analyzer ):
 
     def write(self, setup):
         super(TreeAnalyzerNumpy, self).write(setup)
-        self.file.Write() 
+        if "outputfile" not in setup.services:
+            self.file.Write() 
 

--- a/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
@@ -317,6 +317,7 @@ setattr(JetAnalyzer,"defaultConfig", cfg.Analyzer(
     minLepPt = 10,
     relaxJetId = False,  
     doPuId = False, # Not commissioned in 7.0.X
+    doQG = False, 
     recalibrateJets = False,
     shiftJEC = 0, # set to +1 or -1 to get +/-1 sigma shifts
     smearJets = True,


### PR DESCRIPTION
with this if a tfileservie named "outputfile" is present in the services, the NumpyTreeProducer (and derived) would use such file rather than creating its own.
It also changes the standard behaviour to create the file at beginLoop rather than at init time (as the services are known only at begin loop)

@gpetruc
