### PR TITLE
fixes for cmsRun preprocessor

### DIFF
--- a/PhysicsTools/Heppy/test/example_autofill_wCmsRun.py
+++ b/PhysicsTools/Heppy/test/example_autofill_wCmsRun.py
@@ -110,8 +110,8 @@ testfiles=miniAodFiles()
 
 sample = cfg.Component(
 #specify the file you want to run on
-    files = ["/scratch/arizzi/Hbb/CMSSW_7_2_2_patch2/src/VHbbAnalysis/Heppy/test/ZLL-8A345C56-6665-E411-9C25-1CC1DE04DF20.root"],
-#    files = testfiles,
+#    files = ["/scratch/arizzi/Hbb/CMSSW_7_2_2_patch2/src/VHbbAnalysis/Heppy/test/ZLL-8A345C56-6665-E411-9C25-1CC1DE04DF20.root"],
+    files = testfiles,
     name="SingleSample", isMC=False,isEmbed=False
     )
 

--- a/PhysicsTools/HeppyCore/python/framework/heppy.py
+++ b/PhysicsTools/HeppyCore/python/framework/heppy.py
@@ -204,6 +204,7 @@ if __name__ == '__main__':
 
     parser.add_option("-N", "--nevents",
                       dest="nevents",
+                      type="int",
                       help="number of events to process",
                       default=None)
     parser.add_option("-p", "--nprint",

--- a/PhysicsTools/HeppyCore/python/framework/looper.py
+++ b/PhysicsTools/HeppyCore/python/framework/looper.py
@@ -89,7 +89,13 @@ class Looper(object):
         if len(self.cfg_comp.files)==0:
             errmsg = 'please provide at least an input file in the files attribute of this component\n' + str(self.cfg_comp)
             raise ValueError( errmsg )
-        self.events = config.events_class(self.cfg_comp.files, tree_name)
+        if hasattr(config,"preprocessor") and config.preprocessor is not None :
+              self.cfg_comp = config.preprocessor.run(self.cfg_comp,self.outDir,firstEvent,nEvents)
+        if hasattr(self.cfg_comp,"options"):
+              print self.cfg_comp.files,self.cfg_comp.options
+              self.events = config.events_class(self.cfg_comp.files, tree_name,options=self.cfg_comp.options)
+        else :
+              self.events = config.events_class(self.cfg_comp.files, tree_name)
         if hasattr(self.cfg_comp, 'fineSplit'):
             fineSplitIndex, fineSplitFactor = self.cfg_comp.fineSplit
             if fineSplitFactor > 1:


### PR DESCRIPTION
this contains fixes for running with cmsRun preprocessor
- fix the wrong merge commit on looper.py
- fix the type of nEvents
- restore default tesfiles in the example
  @cbernet @gpetruc @mmarionncern
