### PR TITLE
CMG -> Heppy updates

### DIFF
--- a/PhysicsTools/Heppy/interface/Megajet.h
+++ b/PhysicsTools/Heppy/interface/Megajet.h
@@ -1,0 +1,100 @@
+//-------------------------------------------------------
+// Description:  Razor Megajet calculator
+// Authors:      Maurizio Pierini, CERN
+// Authors:      Christopher Rogan, Javier Duarte, Caltech
+// Authors:      Emanuele Di Marco, CERN
+//-------------------------------------------------------
+
+///  The Megajet class implements the 
+///  algorithm to combine jets in hemispheres
+///  as defined in CMS SUSY  searches
+
+#ifndef Megajet_h
+#define Megajet_h
+
+#include <vector>
+#include <iostream>
+#include <TLorentzVector.h>
+
+namespace heppy {
+
+class Megajet {
+
+public:
+
+  // There are 2 constructors:
+  // 1. Constructor taking as argument vectors of Px, Py, Pz and E of the objects in the event and the hemisphere
+  // association method,
+  // 2. Constructor taking as argument vectors of Px, Py, Pz and E of the objects in the event. 
+  // The hemisphere association method should then be defined by SetMethod(association_method).
+  //
+  // Hemisphere association method:
+  //   1: minimum sum of the invariant masses of the two hemispheres 
+  //   2: minimum difference of HT for the two hemispheres
+  //   3: minimum m1^2/E1 + m2^2/E2
+  //   4: Georgi distance: maximum (E1-Beta*m1^2/E1 + E2-Beta*m1^2/E2)
+
+  Megajet(){};
+
+  Megajet(std::vector<float> Px_vector, std::vector<float> Py_vector, std::vector<float> Pz_vector, std::vector<float> E_vector, int megajet_association_method);
+
+  Megajet(std::vector<float> Px_vector, std::vector<float> Py_vector, std::vector<float> Pz_vector, std::vector<float> E_vector);
+
+  /// Destructor
+  ~Megajet(){};
+
+  // return Nx, Ny, Nz, P, E of the axis of group 1
+  std::vector<float> getAxis1(); 
+  // return Nx, Ny, Nz, P, E of the axis of group 2
+  std::vector<float> getAxis2(); 
+
+  // where Nx, Ny, Nz are the direction cosines e.g. Nx = Px/P, 
+  // P is the momentum, E is the energy
+
+  // set or overwrite the seed and association methods
+  void SetMethod(int megajet_association_method) {
+    megajet_meth = megajet_association_method;
+    status = 0;
+  }
+
+private:
+
+  /// Combining the jets in two hemispheres minimizing the 
+  /// sum of the invariant masses of the two hemispheres
+  void CombineMinMass();
+
+  /// Combining the jets in two hemispheres minimizing the 
+  /// difference of HT for the two hemispheres
+  void CombineMinHT();
+
+  /// Combining the jets in two hemispheres by minimizing m1^2/E1 + m2^2/E2
+  void CombineMinEnergyMass();
+
+  /// Combining the jets in two hemispheres by maximizing (E1-Beta*m1^2/E1 + E2-Beta*m1^2/E2)
+  void CombineGeorgi();
+
+  /// Combine the jets in all the possible pairs of hemispheres
+  void Combine();
+
+
+  std::vector<float> Object_Px;
+  std::vector<float> Object_Py;
+  std::vector<float> Object_Pz;
+  std::vector<float> Object_E;
+
+  std::vector<float> Axis1;
+  std::vector<float> Axis2;
+
+
+  int megajet_meth;
+  int status;
+  
+  std::vector<TLorentzVector> jIN;
+  std::vector<TLorentzVector> jOUT;
+  std::vector<TLorentzVector> j1;
+  std::vector<TLorentzVector> j2;
+
+};
+}
+
+#endif

--- a/PhysicsTools/Heppy/python/analyzers/core/EventSelector.py
+++ b/PhysicsTools/Heppy/python/analyzers/core/EventSelector.py
@@ -7,13 +7,24 @@ class EventSelector( Analyzer ):
     Example:
 
     eventSelector = cfg.Analyzer(
-    'EventSelector',
-    toSelect = [
-    1239742,
-    38001,
-    159832
-    ]
+        'EventSelector',
+        toSelect = [
+            1239742, 
+            38001,
+            159832
+        ]
     )
+
+    it can also be used with (run,lumi,event) tuples:
+
+    eventSelector = cfg.Analyzer(
+        'EventSelector',
+        toSelect = [
+            (1,40,1239742),
+            (1,38,38001),
+        ]
+    )
+
 
     The process function of this analyzer returns False if the event number
     is not in the toSelect list.
@@ -38,7 +49,7 @@ class EventSelector( Analyzer ):
         run = event.input.eventAuxiliary().id().run()
         lumi = event.input.eventAuxiliary().id().luminosityBlock()
         eId = event.input.eventAuxiliary().id().event()
-        if eId in self.cfg_ana.toSelect:
+        if eId in self.cfg_ana.toSelect or (run, lumi, eId) in self.cfg_ana.toSelect:
             # raise ValueError('found')
             print 'Selecting', run, lumi, eId
             return True 

--- a/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
@@ -63,6 +63,7 @@ class JetAnalyzer( Analyzer ):
         self.jetLepDR = getattr(self.cfg_ana, 'jetLepDR', 0.4)
         self.jetLepArbitration = getattr(self.cfg_ana, 'jetLepArbitration', lambda jet,lepton: lepton) 
         self.lepPtMin = getattr(self.cfg_ana, 'minLepPt', -1)
+        self.lepSelCut = getattr(self.cfg_ana, 'lepSelCut', lambda lep : True)
         self.jetGammaDR =  getattr(self.cfg_ana, 'jetGammaDR', 0.4)
         if(self.cfg_ana.doQG):
             self.qglcalc = QGLikelihoodCalculator("/afs/cern.ch/user/t/tomc/public/qgTagger/QGLikelihoodDBFiles/QGL_v1a/pdfQG_AK4chs_antib_13TeV_v1.root")
@@ -125,7 +126,7 @@ class JetAnalyzer( Analyzer ):
         ## Clean Jets from leptons
         leptons = []
         if hasattr(event, 'selectedLeptons'):
-            leptons = [ l for l in event.selectedLeptons if l.pt() > self.lepPtMin ]
+            leptons = [ l for l in event.selectedLeptons if l.pt() > self.lepPtMin and self.lepSelCut(l) ]
         if self.cfg_ana.cleanJetsFromTaus and hasattr(event, 'selectedTaus'):
             leptons = leptons[:] + event.selectedTaus
         if self.cfg_ana.cleanJetsFromIsoTracks and hasattr(event, 'selectedIsoCleanTrack'):
@@ -366,6 +367,7 @@ setattr(JetAnalyzer,"defaultConfig", cfg.Analyzer(
     jetLepDR = 0.4,
     jetLepArbitration = (lambda jet,lepton : lepton), # you can decide which to keep in case of overlaps; e.g. if the jet is b-tagged you might want to keep the jet
     minLepPt = 10,
+    lepSelCut = lambda lep : True,
     relaxJetId = False,  
     doPuId = False, # Not commissioned in 7.0.X
     doQG = False, 

--- a/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
@@ -236,6 +236,11 @@ class LeptonAnalyzer( Analyzer ):
         for mu in allmuons:
             mu.associatedVertex = event.goodVertices[0] if len(event.goodVertices)>0 else event.vertices[0]
 
+        # Set tight id if specified
+        if hasattr(self.cfg_ana, "mu_tightId"):
+            for mu in allmuons:
+               mu.tightIdResult = mu.muonID(self.cfg_ana.mu_tightId)
+ 
         # Compute relIso in 0.3 and 0.4 cones
         for mu in allmuons:
             if self.cfg_ana.mu_isoCorr=="rhoArea" :
@@ -330,7 +335,10 @@ class LeptonAnalyzer( Analyzer ):
             elif self.cfg_ana.ele_tightId=="Cuts_2012" :
                  ele.tightIdResult = -1 + 1*ele.electronID("POG_Cuts_ID_2012_Veto_full5x5") + 1*ele.electronID("POG_Cuts_ID_2012_Loose_full5x5") + 1*ele.electronID("POG_Cuts_ID_2012_Medium_full5x5") + 1*ele.electronID("POG_Cuts_ID_2012_Tight_full5x5")
             else :
-                 raise RuntimeError, "Unsupported ele_tightId name '" + str(self.cfg_ana.ele_tightId) +  "'! For now only 'MVA' and 'Cuts_2012' are supported."
+                 try:
+                     ele.tightIdResult = ele.electronID(self.cfg_ana.ele_tightId)
+                 except RuntimeError:
+                     raise RuntimeError, "Unsupported ele_tightId name '" + str(self.cfg_ana.ele_tightId) +  "'! For now only 'MVA' and 'Cuts_2012' are supported, in addition to what provided in Electron.py."
 
         
         return allelectrons 
@@ -481,6 +489,7 @@ setattr(LeptonAnalyzer,"defaultConfig",cfg.Analyzer(
     # muon isolation correction method (can be "rhoArea" or "deltaBeta")
     mu_isoCorr = "rhoArea" ,
     mu_effectiveAreas = "Phys14_25ns_v1", #(can be 'Data2012' or 'Phys14_25ns_v1')
+    mu_tightId = "POG_ID_Tight" ,
     # electron isolation correction method (can be "rhoArea" or "deltaBeta")
     ele_isoCorr = "rhoArea" ,
     el_effectiveAreas = "Phys14_25ns_v1" , #(can be 'Data2012' or 'Phys14_25ns_v1')

--- a/PhysicsTools/Heppy/python/physicsobjects/Lepton.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Lepton.py
@@ -11,7 +11,7 @@ class Lepton( PhysicsObject):
         '''3D impact parameter significance.'''
         return abs(self.dB(self.PV3D) / self.edB(self.PV3D))
 
-    def absIsoFromEA(self,rho,eta,effectiveArea1 = None,effectiveArea2 = None):
+    def absIsoFromEA(self,area = "04"):
         '''
         Calculate Isolation using the effective area approach. If fsrPhotons is set
         the list of photons is subtracted from the isolation cone. It works with one or
@@ -20,25 +20,10 @@ class Lepton( PhysicsObject):
         photonIso = self.photonIso()
         if hasattr(self,'fsrPhotons'):
             for gamma in self.fsrPhotons:
-                photonIso=photonIso-gamma.pt()                
-        ea1 = rho
-        ea2 = rho
-        if effectiveArea1 is not None:
-            for element in effectiveArea1:
-                if abs(eta)>= element['etaMin'] and \
-                   abs(eta)< element['etaMax']:
-                    ea1 = ea1 * element['area']
-                    break
-        else:
-            return self.chargedHadronIso()+max(0.,photonIso+self.neutralHadronIso()-ea1)
-        if effectiveArea2 is not None:
-            for element in effectiveArea2:
-                if abs(eta)>= element['etaMin'] and \
-                   abs(eta)< element['etaMax']:
-                    ea2 = ea2 * element['area']
-            return self.chargedHadronIso()+max(0.,photonIso-ea1)+max(0.,self.neutralHadronIso()-ea2)
-        else:
-            return self.chargedHadronIso()+max(0.,photonIso+self.neutralHadronIso()-ea1)
+                photonIso=max(photonIso-gamma.pt(),0.0)                
+
+        offset = self.rho*getattr(self,"EffectiveArea"+area)
+        return self.chargedHadronIso()+max(0.,photonIso+self.neutralHadronIso()-offset)            
 
 
     def absIso(self, dBetaFactor=0, allCharged=0):

--- a/PhysicsTools/Heppy/python/physicsobjects/Muon.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Muon.py
@@ -7,8 +7,8 @@ class Muon( Lepton ):
         return self.physObj.isLooseMuon()
 
     def tightId( self ):
-        '''Tight ID as recommended by mu POG.'''
-        return self.muonID("POG_ID_Tight")
+        '''Tight ID as recommended by mu POG (unless redefined in the lepton analyzer).'''
+        return getattr(self,"tightIdResult",self.muonID("POG_ID_Tight"))
 
     def muonID(self, name, vertex=None):
         if name == "" or name is None: 
@@ -31,6 +31,8 @@ class Muon( Lepton ):
                 if not self.looseId(): return False
                 goodGlb = self.physObj.isGlobalMuon() and self.physObj.globalTrack().normalizedChi2() < 3 and self.physObj.combinedQuality().chi2LocalPosition < 12 and self.physObj.combinedQuality().trkKink < 20;
                 return self.physObj.innerTrack().validFraction() >= 0.8 and self.physObj.segmentCompatibility() >= (0.303 if goodGlb else 0.451)
+            if name == "POG_Global_OR_TMArbitrated":
+                return self.physObj.isGlobalMuon() or (self.physObj.isTrackerMuon() and self.physObj.numberOfMatchedStations() > 0)
         return self.physObj.muonID(name)
             
     def mvaId(self):

--- a/PhysicsTools/Heppy/src/Megajet.cc
+++ b/PhysicsTools/Heppy/src/Megajet.cc
@@ -1,0 +1,225 @@
+#include "PhysicsTools/Heppy/interface/Megajet.h"
+
+#include <vector>
+#include <math.h>
+#include <TLorentzVector.h>
+
+using namespace std;
+
+namespace heppy {
+
+// constructor specifying the association methods
+Megajet::Megajet(vector<float> Px_vector, vector<float> Py_vector, vector<float> Pz_vector,
+                 vector<float> E_vector, int megajet_association_method) : 
+  Object_Px(Px_vector), Object_Py(Py_vector), Object_Pz(Pz_vector), Object_E(E_vector), 
+  megajet_meth(megajet_association_method),  status(0) { 
+
+  if(Object_Px.size() < 2) cout << "Error in Megajet: you should provide at least two jets to form Megajets" << endl;
+  for(int j=0; j<(int)jIN.size(); ++j) {
+    jIN.push_back(TLorentzVector(Object_Px[j],Object_Py[j],Object_Pz[j],Object_E[j]));
+  }
+}
+
+// constructor without specification of the seed and association methods
+// in this case, the latter must be given by calling SetMethod before invoking Combine()
+Megajet::Megajet(vector<float> Px_vector, vector<float> Py_vector, vector<float> Pz_vector,
+                 vector<float> E_vector) : 
+  Object_Px(Px_vector), Object_Py(Py_vector), Object_Pz(Pz_vector), Object_E(E_vector), 
+  status(0) { 
+
+  if(Object_Px.size() < 2) cout << "Error in Megajet: you should provide at least two jets to form Megajets" << endl;
+  for(int j=0; j<(int)jIN.size(); ++j) {
+    jIN.push_back(TLorentzVector(Object_Px[j],Object_Py[j],Object_Pz[j],Object_E[j]));
+  }
+}
+
+vector<float> Megajet::getAxis1(){
+  if (status != 1) {
+    this->Combine();
+    if( megajet_meth == 1) this->CombineMinMass();
+    else if(megajet_meth == 2) this->CombineMinHT();
+    else if(megajet_meth == 3) this->CombineMinEnergyMass();
+    else if(megajet_meth == 4) this->CombineGeorgi();
+    else this->CombineMinMass();
+  }
+  if(jIN.size() > 1) {
+    Axis1[0] = jOUT[0].Px() / jOUT[0].P();
+    Axis1[1] = jOUT[0].Py() / jOUT[0].P();
+    Axis1[2] = jOUT[0].Pz() / jOUT[0].P();
+    Axis1[3] = jOUT[0].P();
+    Axis1[4] = jOUT[0].E();
+  }
+  return Axis1;
+}
+vector<float> Megajet::getAxis2(){
+  if (status != 1) {
+    this->Combine();
+    if( megajet_meth == 1) this->CombineMinMass();
+    else if(megajet_meth == 2) this->CombineMinHT();
+    else if(megajet_meth == 3) this->CombineMinEnergyMass();
+    else if(megajet_meth == 4) this->CombineGeorgi();
+    else this->CombineMinMass();
+  }
+  if(jIN.size() > 1) {
+    Axis2[0] = jOUT[1].Px() / jOUT[1].P();
+    Axis2[1] = jOUT[1].Py() / jOUT[1].P();
+    Axis2[2] = jOUT[1].Pz() / jOUT[1].P();
+    Axis2[3] = jOUT[1].P();
+    Axis2[4] = jOUT[1].E();
+  }
+  return Axis2;
+}
+
+void Megajet::Combine() {
+  int N_JETS = (int)jIN.size();
+
+  int N_comb = 1;
+  for(int i = 0; i < N_JETS; i++){
+    N_comb *= 2;
+  }
+    
+  // clear some vectors if method Combine() is called again
+  if ( !j1.empty() ) {
+    j1.clear();
+    j2.clear();
+    Axis1.clear();
+    Axis2.clear();
+  }
+
+  for(int j = 0; j < 5; ++j){
+    Axis1.push_back(0);
+    Axis2.push_back(0);
+  }
+
+  int j_count;
+  for(int i = 1; i < N_comb-1; i++){
+    TLorentzVector j_temp1, j_temp2;
+    int itemp = i;
+    j_count = N_comb/2;
+    int count = 0;
+    while(j_count > 0){
+      if(itemp/j_count == 1){
+	j_temp1 += jIN[count];
+      } else {
+	j_temp2 += jIN[count];
+      }
+      itemp -= j_count*(itemp/j_count);
+      j_count /= 2;
+      count++;
+    }
+
+    j1.push_back(j_temp1);
+    j2.push_back(j_temp2);
+  }
+}
+
+void Megajet::CombineMinMass() {
+  double M_min = -1;
+  // default value (in case none is found)
+  TLorentzVector myJ1 = TLorentzVector(0,0,0,0);
+  TLorentzVector myJ2 = TLorentzVector(0,0,0,0);
+  for(int i=0; i<(int)j1.size(); i++) {
+    double M_temp = j1[i].M2()+j2[i].M2();
+    if(M_min < 0 || M_temp < M_min){
+      M_min = M_temp;
+      myJ1 = j1[i];
+      myJ2 = j2[i];
+    }
+  }
+  //  myJ1.SetPtEtaPhiM(myJ1.Pt(),myJ1.Eta(),myJ1.Phi(),0.0);
+  //  myJ2.SetPtEtaPhiM(myJ2.Pt(),myJ2.Eta(),myJ2.Phi(),0.0);
+
+  jOUT.clear();
+  if(myJ1.Pt() > myJ2.Pt()){
+    jOUT.push_back(myJ1);
+    jOUT.push_back(myJ2);
+  } else {
+    jOUT.push_back(myJ2);
+    jOUT.push_back(myJ1);
+  }
+  status=1;
+}
+
+void Megajet::CombineMinEnergyMass() {
+  double M_min = -1;
+  // default value (in case none is found)
+  TLorentzVector myJ1 = TLorentzVector(0,0,0,0);
+  TLorentzVector myJ2 = TLorentzVector(0,0,0,0);
+  for(int i=0; i<(int)j1.size(); i++) {
+    double M_temp = j1[i].M2()/j1[i].E()+j2[i].M2()/j2[i].E();
+    if(M_min < 0 || M_temp < M_min){
+      M_min = M_temp;
+      myJ1 = j1[i];
+      myJ2 = j2[i];
+    }
+  }
+  
+  //  myJ1.SetPtEtaPhiM(myJ1.Pt(),myJ1.Eta(),myJ1.Phi(),0.0);
+  //  myJ2.SetPtEtaPhiM(myJ2.Pt(),myJ2.Eta(),myJ2.Phi(),0.0);
+
+  jOUT.clear();
+  if(myJ1.Pt() > myJ2.Pt()){
+    jOUT.push_back(myJ1);
+    jOUT.push_back(myJ2);
+  } else {
+    jOUT.push_back(myJ2);
+    jOUT.push_back(myJ1);
+  }
+  status=1;
+}
+
+void Megajet::CombineGeorgi(){
+  double M_max = -10000;
+  // default value (in case none is found)
+  TLorentzVector myJ1 = TLorentzVector(0,0,0,0);
+  TLorentzVector myJ2 = TLorentzVector(0,0,0,0);
+  for(int i=0; i<(int)j1.size(); i++) {
+    int myBeta = 2;
+    double M_temp = (j1[i].E()-myBeta*j1[i].M2()/j1[i].E())+(j2[i].E()-myBeta*j2[i].M2()/j2[i].E());
+    if(M_max < -9999 || M_temp > M_max){
+      M_max = M_temp;
+      myJ1 = j1[i];
+      myJ2 = j2[i];
+    }
+  }
+  
+  //  myJ1.SetPtEtaPhiM(myJ1.Pt(),myJ1.Eta(),myJ1.Phi(),0.0);
+  //  myJ2.SetPtEtaPhiM(myJ2.Pt(),myJ2.Eta(),myJ2.Phi(),0.0);
+
+  jOUT.clear();
+  if(myJ1.Pt() > myJ2.Pt()){
+    jOUT.push_back(myJ1);
+    jOUT.push_back(myJ2);
+  } else {
+    jOUT.push_back(myJ2);
+    jOUT.push_back(myJ1);
+  }
+  status=1;
+}
+
+void Megajet::CombineMinHT() {
+  double dHT_min = 999999999999999.0;
+  // default value (in case none is found)
+  TLorentzVector myJ1 = TLorentzVector(0,0,0,0);
+  TLorentzVector myJ2 = TLorentzVector(0,0,0,0);
+  for(int i=0; i<(int)j1.size(); i++) {
+    double dHT_temp = fabs(j1[i].E()-j2[i].E());
+    if(dHT_temp < dHT_min){  
+      dHT_min = dHT_temp;
+      myJ1 = j1[i];
+      myJ2 = j2[i];
+    }
+  }
+  
+  jOUT.clear();
+  if(myJ1.Pt() > myJ2.Pt()){
+    jOUT.push_back(myJ1);
+    jOUT.push_back(myJ2);
+  } else {
+    jOUT.push_back(myJ2);
+    jOUT.push_back(myJ1);
+  }
+  status=1;
+}
+
+}

--- a/PhysicsTools/Heppy/src/classes.h
+++ b/PhysicsTools/Heppy/src/classes.h
@@ -11,6 +11,7 @@
 #include "PhysicsTools/Heppy/interface/Hemisphere.h"
 #include "PhysicsTools/Heppy/interface/AlphaT.h"
 #include "PhysicsTools/Heppy/interface/Apc.h"
+#include "PhysicsTools/Heppy/interface/Megajet.h"
 #include "PhysicsTools/Heppy/interface/ReclusterJets.h"
 #include "PhysicsTools/Heppy/interface/IsolationComputer.h"
 
@@ -37,6 +38,7 @@ namespace {
     heppy::mt2w_bisect::mt2w mt2wlept;
     heppy::AlphaT alphaT;
     heppy::Apc apc;
+    heppy::Megajet megajet;
     heppy::ReclusterJets reclusterJets(std::vector<float> px, std::vector<float> py, std::vector<float> pz, std::vector<float> E, double ktpower, double rparam);
     //  heppy::SimpleElectron fuffaElectron;
     //  ElectronEnergyCalibrator fuffaElectronCalibrator;

--- a/PhysicsTools/Heppy/src/classes_def.xml
+++ b/PhysicsTools/Heppy/src/classes_def.xml
@@ -12,6 +12,7 @@
   <class name="heppy::EGammaMvaEleEstimatorFWLite" transient="true" />
   <class name="heppy::AlphaT" transient="true" />
   <class name="heppy::Apc" transient="true" />
+  <class name="heppy::Megajet" transient="true" />
   <class name="heppy::ReclusterJets"  transient="true"/>
   <class name="heppy::IsolationComputer"  transient="true"/>
 


### PR DESCRIPTION
- add Phys14 cut-based eleID WPs, updated CSA14 cut-based eleID WPs
- add options for cleaning of gen jets
- add `mcPt`variable for leptons and photons
- in the event selector, allow passing `(run,lumi,event)` tuples instead of bare events
- allow setting the electron tight id also to anything recognized by the `electronID` method, and same also for the muon
- add an optional `lepCut` parameter to the jet cleaner to apply a preselection to the leptons used in jet cleaning (e.g. for applying a tighter id)
- support for sub-objects in an object type
