### PR TITLE
Heppy updates to support the new electron IDs

### DIFF
--- a/EgammaAnalysis/ElectronTools/interface/EGammaMvaEleEstimator.h
+++ b/EgammaAnalysis/ElectronTools/interface/EGammaMvaEleEstimator.h
@@ -34,6 +34,7 @@
 #include "TMVA/Factory.h"
 #include "TMVA/Tools.h"
 #include "TMVA/Reader.h"
+#include "TMVA/MethodBase.h"
 
 class EGammaMvaEleEstimator{
   public:
@@ -86,6 +87,7 @@ class EGammaMvaEleEstimator{
     Double_t mvaValue(const pat::Electron& ele,
 		      const reco::Vertex& vertex,
 		      double rho,
+                      bool useFull5x5 = kFALSE,
 		      bool printDebug = kFALSE);
     
     Double_t isoMvaValue(const reco::GsfElectron& ele, 
@@ -245,6 +247,7 @@ class EGammaMvaEleEstimator{
   private:
 
     std::vector<TMVA::Reader*> fTMVAReader;
+    std::vector<TMVA::MethodBase*> fTMVAMethod;
     std::string                fMethodname;
     Bool_t                     fisInitialized;
     MVAType                    fMVAType;

--- a/PhysicsTools/Heppy/interface/EGammaMvaEleEstimatorFWLite.h
+++ b/PhysicsTools/Heppy/interface/EGammaMvaEleEstimatorFWLite.h
@@ -2,6 +2,7 @@
 #define PhysicsTools_Heppy_EGammaMvaEleEstimatorFWLite_h
 
 struct EGammaMvaEleEstimator;
+struct EGammaMvaEleEstimatorCSA14;
 namespace reco { struct Vertex; }
 namespace pat { struct Electron; }
 #include <vector>
@@ -18,6 +19,9 @@ class EGammaMvaEleEstimatorFWLite {
             kTrig = 0, // MVA for triggering electrons
             kTrigNoIP = 1, // MVA for triggering electrons without IP info
             kNonTrig = 2, // MVA for non-triggering electrons 
+            kTrigCSA14 = 3, // MVA for non-triggering electrons 
+            kNonTrigCSA14 = 4, // MVA for non-triggering electrons 
+            kNonTrigPhys14 = 5, // MVA for non-triggering electrons 
         };
 
         void initialize( std::string methodName,
@@ -32,6 +36,7 @@ class EGammaMvaEleEstimatorFWLite {
                 bool printDebug = false);
     private:
         EGammaMvaEleEstimator *estimator_;
+        EGammaMvaEleEstimatorCSA14 *estimatorCSA14_;
 };
 }
 #endif

--- a/PhysicsTools/Heppy/interface/Megajet.h
+++ b/PhysicsTools/Heppy/interface/Megajet.h
@@ -1,0 +1,100 @@
+//-------------------------------------------------------
+// Description:  Razor Megajet calculator
+// Authors:      Maurizio Pierini, CERN
+// Authors:      Christopher Rogan, Javier Duarte, Caltech
+// Authors:      Emanuele Di Marco, CERN
+//-------------------------------------------------------
+
+///  The Megajet class implements the 
+///  algorithm to combine jets in hemispheres
+///  as defined in CMS SUSY  searches
+
+#ifndef Megajet_h
+#define Megajet_h
+
+#include <vector>
+#include <iostream>
+#include <TLorentzVector.h>
+
+namespace heppy {
+
+class Megajet {
+
+public:
+
+  // There are 2 constructors:
+  // 1. Constructor taking as argument vectors of Px, Py, Pz and E of the objects in the event and the hemisphere
+  // association method,
+  // 2. Constructor taking as argument vectors of Px, Py, Pz and E of the objects in the event. 
+  // The hemisphere association method should then be defined by SetMethod(association_method).
+  //
+  // Hemisphere association method:
+  //   1: minimum sum of the invariant masses of the two hemispheres 
+  //   2: minimum difference of HT for the two hemispheres
+  //   3: minimum m1^2/E1 + m2^2/E2
+  //   4: Georgi distance: maximum (E1-Beta*m1^2/E1 + E2-Beta*m1^2/E2)
+
+  Megajet(){};
+
+  Megajet(std::vector<float> Px_vector, std::vector<float> Py_vector, std::vector<float> Pz_vector, std::vector<float> E_vector, int megajet_association_method);
+
+  Megajet(std::vector<float> Px_vector, std::vector<float> Py_vector, std::vector<float> Pz_vector, std::vector<float> E_vector);
+
+  /// Destructor
+  ~Megajet(){};
+
+  // return Nx, Ny, Nz, P, E of the axis of group 1
+  std::vector<float> getAxis1(); 
+  // return Nx, Ny, Nz, P, E of the axis of group 2
+  std::vector<float> getAxis2(); 
+
+  // where Nx, Ny, Nz are the direction cosines e.g. Nx = Px/P, 
+  // P is the momentum, E is the energy
+
+  // set or overwrite the seed and association methods
+  void SetMethod(int megajet_association_method) {
+    megajet_meth = megajet_association_method;
+    status = 0;
+  }
+
+private:
+
+  /// Combining the jets in two hemispheres minimizing the 
+  /// sum of the invariant masses of the two hemispheres
+  void CombineMinMass();
+
+  /// Combining the jets in two hemispheres minimizing the 
+  /// difference of HT for the two hemispheres
+  void CombineMinHT();
+
+  /// Combining the jets in two hemispheres by minimizing m1^2/E1 + m2^2/E2
+  void CombineMinEnergyMass();
+
+  /// Combining the jets in two hemispheres by maximizing (E1-Beta*m1^2/E1 + E2-Beta*m1^2/E2)
+  void CombineGeorgi();
+
+  /// Combine the jets in all the possible pairs of hemispheres
+  void Combine();
+
+
+  std::vector<float> Object_Px;
+  std::vector<float> Object_Py;
+  std::vector<float> Object_Pz;
+  std::vector<float> Object_E;
+
+  std::vector<float> Axis1;
+  std::vector<float> Axis2;
+
+
+  int megajet_meth;
+  int status;
+  
+  std::vector<TLorentzVector> jIN;
+  std::vector<TLorentzVector> jOUT;
+  std::vector<TLorentzVector> j1;
+  std::vector<TLorentzVector> j2;
+
+};
+}
+
+#endif

--- a/PhysicsTools/Heppy/python/physicsobjects/Electron.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Electron.py
@@ -1,5 +1,5 @@
 from PhysicsTools.Heppy.physicsobjects.Lepton import Lepton
-from PhysicsTools.Heppy.physicsutils.ElectronMVAID import ElectronMVAID_Trig, ElectronMVAID_NonTrig, ElectronMVAID_TrigNoIP
+from PhysicsTools.Heppy.physicsutils.ElectronMVAID import *
 import ROOT
 
 class Electron( Lepton ):
@@ -18,6 +18,7 @@ class Electron( Lepton ):
         self._mvaNonTrigV0  = {True:None, False:None}
         self._mvaTrigV0     = {True:None, False:None}
         self._mvaTrigNoIPV0 = {True:None, False:None}
+        self._mvaRun2 = {}
 
     def electronID( self, id, vertex=None, rho=None ):
         if id is None or id == "": return True
@@ -27,8 +28,10 @@ class Electron( Lepton ):
         elif id == "POG_MVA_ID_Trig":     return self.mvaIDTight()
         elif id == "POG_MVA_ID_NonTrig_full5x5":  return self.mvaIDLoose(full5x5=True)
         elif id == "POG_MVA_ID_Trig_full5x5":     return self.mvaIDTight(full5x5=True)
-        elif id.startswith("POG_Cuts_ID_"): 
-                return self.cutBasedId(id.replace("POG_Cuts_ID_","POG_")) 
+        elif id == "POG_MVA_ID_Run2_NonTrig_Loose":    return self.mvaIDRun2("NonTrigPhys14","Loose")
+        elif id == "POG_MVA_ID_Run2_NonTrig_Tight":    return self.mvaIDRun2("NonTrigPhys14","Tight")
+        elif id.startswith("POG_Cuts_ID_"):
+                return self.cutBasedId(id.replace("POG_Cuts_ID_","POG_"))
         for ID in self.electronIDs():
             if ID.first == id:
                 return ID.second
@@ -39,7 +42,7 @@ class Electron( Lepton ):
             showerShapes = "full5x5"
             wp = wp.replace("_full5x5","")
         elif showerShapes == "auto":
-            if "POG_CSA14_25ns_v1" in wp or "POG_CSA14_50ns_v1" in wp:
+            if "POG_CSA14_25ns_v1" in wp or "POG_CSA14_50ns_v1" in wp or "POG_PHYS14_25ns_v1" in wp:
                 showerShapes = "full5x5"
         vars = {
             'dEtaIn' : abs(self.physObj.deltaEtaSuperClusterTrackAtVtx()),
@@ -48,6 +51,8 @@ class Electron( Lepton ):
             'H/E' : self.physObj.hadronicOverEm(),
             #'1/E-1/p' : abs(1.0/self.physObj.ecalEnergy() - self.physObj.eSuperClusterOverP()/self.physObj.ecalEnergy()),
             '1/E-1/p' : abs(1.0/self.physObj.ecalEnergy() - self.physObj.eSuperClusterOverP()/self.physObj.ecalEnergy()) if self.physObj.ecalEnergy()>0. else 9e9,
+            'conversionVeto' : self.physObj.passConversionVeto(),
+            'missingHits' : self.physObj.gsfTrack().hitPattern().numberOfHits(ROOT.reco.HitPattern.MISSING_INNER_HITS), # http://cmslxr.fnal.gov/source/DataFormats/TrackReco/interface/HitPattern.h?v=CMSSW_7_2_3#0153
         }
         WP = {
             ## ------- https://twiki.cern.ch/twiki/bin/viewauth/CMS/EgammaCutBasedIdentification?rev=31
@@ -55,23 +60,52 @@ class Electron( Lepton ):
             'POG_2012_Loose'  :  [('dEtaIn', [0.007, 0.009]), ('dPhiIn', [0.15, 0.1 ]), ('sigmaIEtaIEta', [0.01, 0.03]), ('H/E', [0.12, 0.1]), ('1/E-1/p', [0.05, 0.05])],
             'POG_2012_Medium' :  [('dEtaIn', [0.004, 0.007]), ('dPhiIn', [0.06, 0.03]), ('sigmaIEtaIEta', [0.01, 0.03]), ('H/E', [0.12, 0.1]), ('1/E-1/p', [0.05, 0.05])],
             'POG_2012_Tight'  :  [('dEtaIn', [0.004, 0.005]), ('dPhiIn', [0.03, 0.02]), ('sigmaIEtaIEta', [0.01, 0.03]), ('H/E', [0.12, 0.1]), ('1/E-1/p', [0.05, 0.05])],
-            ## ------- https://indico.cern.cH/Event/298242/contribution/1/material/slides/5.pdf (slide 5)
-            'POG_CSA14_25ns_v1_Veto'   :  [('dEtaIn', [0.012, 0.015]), ('dPhiIn', [0.8,  0.7 ]), ('sigmaIEtaIEta', [0.01 , 0.033]), ('H/E', [0.15, 9e9 ]), ('1/E-1/p', [9e9,   9e9])],
-            'POG_CSA14_25ns_v1_Loose'  :  [('dEtaIn', [0.012, 0.014]), ('dPhiIn', [0.15, 0.1 ]), ('sigmaIEtaIEta', [0.01 , 0.033]), ('H/E', [0.12, 0.12]), ('1/E-1/p', [0.05, 0.05])],
-            'POG_CSA14_25ns_v1_Medium' :  [('dEtaIn', [0.009, 0.012]), ('dPhiIn', [0.06, 0.03]), ('sigmaIEtaIEta', [0.01 , 0.031]), ('H/E', [0.12, 0.12]), ('1/E-1/p', [0.05, 0.05])],
-            'POG_CSA14_25ns_v1_Tight'  :  [('dEtaIn', [0.009, 0.010]), ('dPhiIn', [0.03, 0.02]), ('sigmaIEtaIEta', [0.01 , 0.031]), ('H/E', [0.12, 0.12]), ('1/E-1/p', [0.05, 0.05])],
-            'POG_CSA14_50ns_v1_Veto'   :  [('dEtaIn', [0.012, 0.022]), ('dPhiIn', [0.8,  0.7 ]), ('sigmaIEtaIEta', [0.012, 0.033]), ('H/E', [0.15, 9e9 ]), ('1/E-1/p', [9e9,   9e9])],
-            'POG_CSA14_50ns_v1_Loose'  :  [('dEtaIn', [0.012, 0.021]), ('dPhiIn', [0.15, 0.1 ]), ('sigmaIEtaIEta', [0.012, 0.033]), ('H/E', [0.12, 0.12]), ('1/E-1/p', [0.05, 0.05])],
-            'POG_CSA14_50ns_v1_Medium' :  [('dEtaIn', [0.009, 0.019]), ('dPhiIn', [0.06, 0.03]), ('sigmaIEtaIEta', [0.01 , 0.031]), ('H/E', [0.12, 0.12]), ('1/E-1/p', [0.05, 0.05])],
-            'POG_CSA14_50ns_v1_Tight'  :  [('dEtaIn', [0.009, 0.017]), ('dPhiIn', [0.03, 0.02]), ('sigmaIEtaIEta', [0.01 , 0.031]), ('H/E', [0.12, 0.12]), ('1/E-1/p', [0.05, 0.05])],
+            # RIC: in the EG POG WPs, isolation is included too. Here only the pure ID part.
+            # dz and d0 cuts are excluded here as well.
+            ## ------- https://twiki.cern.ch/twiki/bin/viewauth/CMS/CutBasedElectronIdentificationRun2#Working_points_for_CSA14_samples?rev=13
+            'POG_CSA14_25ns_v1_Veto'   :  [('dEtaIn', [0.017938, 0.014569]), ('dPhiIn', [0.182958, 0.230914]), ('sigmaIEtaIEta', [0.012708, 0.036384]), ('H/E', [0.335015, 0.200792]), ('1/E-1/p', [0.198287, 0.146856])],
+            'POG_CSA14_25ns_v1_Loose'  :  [('dEtaIn', [0.014928, 0.013045]), ('dPhiIn', [0.141050, 0.149017]), ('sigmaIEtaIEta', [0.011304, 0.035536]), ('H/E', [0.127690, 0.107898]), ('1/E-1/p', [0.097806, 0.102261])],
+            'POG_CSA14_25ns_v1_Medium' :  [('dEtaIn', [0.013071, 0.010006]), ('dPhiIn', [0.132113, 0.052321]), ('sigmaIEtaIEta', [0.010726, 0.032882]), ('H/E', [0.109761, 0.101755]), ('1/E-1/p', [0.032639, 0.041427])],
+            'POG_CSA14_25ns_v1_Tight'  :  [('dEtaIn', [0.012671, 0.008823]), ('dPhiIn', [0.025218, 0.027286]), ('sigmaIEtaIEta', [0.010061, 0.030222]), ('H/E', [0.065085, 0.090710]), ('1/E-1/p', [0.027873, 0.019404])],
+            'POG_CSA14_50ns_v1_Veto'   :  [('dEtaIn', [0.021, 0.028]), ('dPhiIn', [0.25 , 0.23 ]), ('sigmaIEtaIEta', [0.012, 0.035]), ('H/E', [0.24 , 0.19 ]), ('1/E-1/p', [0.32 , 0.13 ])],
+            'POG_CSA14_50ns_v1_Loose'  :  [('dEtaIn', [0.016, 0.025]), ('dPhiIn', [0.080, 0.097]), ('sigmaIEtaIEta', [0.012, 0.032]), ('H/E', [0.15 , 0.12 ]), ('1/E-1/p', [0.11 , 0.11 ])],
+            'POG_CSA14_50ns_v1_Medium' :  [('dEtaIn', [0.015, 0.023]), ('dPhiIn', [0.051, 0.056]), ('sigmaIEtaIEta', [0.010, 0.030]), ('H/E', [0.10 , 0.099]), ('1/E-1/p', [0.053, 0.11 ])],
+            'POG_CSA14_50ns_v1_Tight'  :  [('dEtaIn', [0.012, 0.019]), ('dPhiIn', [0.024, 0.043]), ('sigmaIEtaIEta', [0.010, 0.029]), ('H/E', [0.074, 0.080]), ('1/E-1/p', [0.026, 0.076])],
+            ## ------- https://twiki.cern.ch/twiki/bin/viewauth/CMS/CutBasedElectronIdentificationRun2#Working_points_for_PHYS14_sample?rev=13
+            'POG_PHYS14_25ns_v1_Veto'   :  [('dEtaIn', [0.016315, 0.010671]), ('dPhiIn', [0.252044, 0.245263]), ('sigmaIEtaIEta', [0.011100 , 0.033987]), ('H/E', [0.345843, 0.134691]), ('1/E-1/p', [0.248070, 0.157160])],
+            'POG_PHYS14_25ns_v1_Loose'  :  [('dEtaIn', [0.012442, 0.010654]), ('dPhiIn', [0.072624, 0.145129]), ('sigmaIEtaIEta', [0.010557 , 0.032602]), ('H/E', [0.121476, 0.131862]), ('1/E-1/p', [0.221803, 0.142283])],
+            'POG_PHYS14_25ns_v1_Medium' :  [('dEtaIn', [0.007641, 0.009285]), ('dPhiIn', [0.032643, 0.042447]), ('sigmaIEtaIEta', [0.010399 , 0.029524]), ('H/E', [0.060662, 0.104263]), ('1/E-1/p', [0.153897, 0.137468])],
+            'POG_PHYS14_25ns_v1_Tight'  :  [('dEtaIn', [0.006574, 0.005681]), ('dPhiIn', [0.022868, 0.032046]), ('sigmaIEtaIEta', [0.010181 , 0.028766]), ('H/E', [0.037553, 0.081902]), ('1/E-1/p', [0.131191, 0.106055])],
         }
-        if wp not in WP: 
+        WP_conversion_veto = {
+            # missing Hits incremented by 1 because we return False if >=, note the '='
+            ## ------- https://twiki.cern.ch/twiki/bin/viewauth/CMS/CutBasedElectronIdentificationRun2#Working_points_for_CSA14_samples?rev=13
+            'POG_CSA14_25ns_v1_ConvVeto_Veto'   :  WP['POG_CSA14_25ns_v1_Veto'  ]+[('conversionVeto', [True, True]), ('missingHits', [3, 4])],
+            'POG_CSA14_25ns_v1_ConvVeto_Loose'  :  WP['POG_CSA14_25ns_v1_Loose' ]+[('conversionVeto', [True, True]), ('missingHits', [2, 2])],
+            'POG_CSA14_25ns_v1_ConvVeto_Medium' :  WP['POG_CSA14_25ns_v1_Medium']+[('conversionVeto', [True, True]), ('missingHits', [2, 2])],
+            'POG_CSA14_25ns_v1_ConvVeto_Tight'  :  WP['POG_CSA14_25ns_v1_Tight' ]+[('conversionVeto', [True, True]), ('missingHits', [2, 2])],
+            'POG_CSA14_50ns_v1_ConvVeto_Veto'   :  WP['POG_CSA14_50ns_v1_Veto'  ]+[('conversionVeto', [True, True]), ('missingHits', [3, 4])],
+            'POG_CSA14_50ns_v1_ConvVeto_Loose'  :  WP['POG_CSA14_50ns_v1_Loose' ]+[('conversionVeto', [True, True]), ('missingHits', [2, 2])],
+            'POG_CSA14_50ns_v1_ConvVeto_Medium' :  WP['POG_CSA14_50ns_v1_Medium']+[('conversionVeto', [True, True]), ('missingHits', [2, 2])],
+            'POG_CSA14_50ns_v1_ConvVeto_Tight'  :  WP['POG_CSA14_50ns_v1_Tight' ]+[('conversionVeto', [True, True]), ('missingHits', [2, 2])],
+            ## ------- https://twiki.cern.ch/twiki/bin/viewauth/CMS/CutBasedElectronIdentificationRun2#Working_points_for_PHYS14_sample?rev=13
+            'POG_PHYS14_25ns_v1_ConvVeto_Veto'   :  WP['POG_PHYS14_25ns_v1_Veto'  ]+[('conversionVeto', [True, True]), ('missingHits', [3, 4])],
+            'POG_PHYS14_25ns_v1_ConvVeto_Loose'  :  WP['POG_PHYS14_25ns_v1_Loose' ]+[('conversionVeto', [True, True]), ('missingHits', [2, 2])],
+            'POG_PHYS14_25ns_v1_ConvVeto_Medium' :  WP['POG_PHYS14_25ns_v1_Medium']+[('conversionVeto', [True, True]), ('missingHits', [2, 2])],
+            'POG_PHYS14_25ns_v1_ConvVeto_Tight'  :  WP['POG_PHYS14_25ns_v1_Tight' ]+[('conversionVeto', [True, True]), ('missingHits', [2, 2])],
+        }
+
+        WP.update(WP_conversion_veto)
+
+        if wp not in WP:
             raise RuntimeError, "Working point '%s' not yet implemented in Electron.py" % wp
         for (cut_name,(cut_eb,cut_ee)) in WP[wp]:
-            if vars[cut_name] >= (cut_eb if self.physObj.isEB() else cut_ee):
+            if cut_name == 'conversionVeto':
+                return vars[cut_name] == (cut_eb if self.physObj.isEB() else cut_ee)
+            elif vars[cut_name] >= (cut_eb if self.physObj.isEB() else cut_ee):
                 return False
         return True
- 
+
     def absEffAreaIso(self,rho,effectiveAreas):
         '''MIKE, missing doc.
         Should have the same name as the function in the mother class.
@@ -81,31 +115,38 @@ class Electron( Lepton ):
 
     def mvaId( self ):
         return self.mvaNonTrigV0()
-        
+
     def tightId( self ):
         return self.tightIdResult
-    
+
     def mvaNonTrigV0( self, full5x5=False, debug = False ):
         if self._mvaNonTrigV0[full5x5] == None:
             if self.associatedVertex == None: raise RuntimeError, "You need to set electron.associatedVertex before calling any MVA"
             if self.rho              == None: raise RuntimeError, "You need to set electron.rho before calling any MVA"
             self._mvaNonTrigV0[full5x5] = ElectronMVAID_NonTrig(self.physObj, self.associatedVertex, self.rho, full5x5, debug)
-        return self._mvaNonTrigV0[full5x5] 
+        return self._mvaNonTrigV0[full5x5]
 
     def mvaTrigV0( self, full5x5=False, debug = False ):
         if self._mvaTrigV0[full5x5] == None:
             if self.associatedVertex == None: raise RuntimeError, "You need to set electron.associatedVertex before calling any MVA"
             if self.rho              == None: raise RuntimeError, "You need to set electron.rho before calling any MVA"
             self._mvaTrigV0[full5x5] = ElectronMVAID_Trig(self.physObj, self.associatedVertex, self.rho, full5x5, debug)
-        return self._mvaTrigV0[full5x5] 
+        return self._mvaTrigV0[full5x5]
 
     def mvaTrigNoIPV0( self, full5x5=False, debug = False ):
         if self._mvaTrigNoIPV0[full5x5] == None:
             if self.associatedVertex == None: raise RuntimeError, "You need to set electron.associatedVertex before calling any MVA"
             if self.rho              == None: raise RuntimeError, "You need to set electron.rho before calling any MVA"
             self._mvaTrigNoIPV0[full5x5] = ElectronMVAID_TrigNoIP(self.physObj, self.associatedVertex, self.rho, full5x5, debug)
-        return self._mvaTrigNoIPV0[full5x5] 
+        return self._mvaTrigNoIPV0[full5x5]
 
+    def mvaRun2( self, name, debug = False ):
+        if name not in self._mvaRun2:
+            if name not in ElectronMVAID_ByName: raise RuntimeError, "Unknown electron run2 mva id %s (known ones are: %s)\n" % (name, ElectronMVAID_ByName.keys())
+            if self.associatedVertex == None: raise RuntimeError, "You need to set electron.associatedVertex before calling any MVA"
+            if self.rho              == None: raise RuntimeError, "You need to set electron.rho before calling any MVA"
+            self._mvaRun2[name] = ElectronMVAID_ByName[name](self.physObj, self.associatedVertex, self.rho, True, debug)
+        return self._mvaRun2[name]
 
     def mvaIDTight(self, full5x5=False):
             eta = abs(self.superCluster().eta())
@@ -129,33 +170,48 @@ class Electron( Lepton ):
                 elif (eta < 1.479): return self.mvaNonTrigV0(full5x5) > -0.65;
                 else              : return self.mvaNonTrigV0(full5x5) > +0.60;
 
+    def mvaIDRun2(self, name, wp):
+            eta = abs(self.superCluster().eta())
+            if name == "NonTrigPhys14":
+                if wp=="Loose":
+                    if   (eta < 0.8)  : return self.mvaRun2(name) > +0.35;
+                    elif (eta < 1.479): return self.mvaRun2(name) > +0.20;
+                    else              : return self.mvaRun2(name) > -0.52;
+                elif wp=="Tight":
+                    if   (eta < 0.8)  : return self.mvaRun2(name) > 0.73;
+                    elif (eta < 1.479): return self.mvaRun2(name) > 0.57;
+                    else              : return self.mvaRun2(name) > 0.05;
+                else: raise RuntimeError, "Ele MVA ID Working point not found"
+            else: raise RuntimeError, "Ele MVA ID type not found"
+
+
     def mvaIDZZ(self):
         return self.mvaIDLoose() and (self.gsfTrack().trackerExpectedHitsInner().numberOfLostHits()<=1)
 
     def chargedHadronIsoR(self,R=0.4):
-        if   R == 0.3: return self.physObj.pfIsolationVariables().sumChargedHadronPt 
+        if   R == 0.3: return self.physObj.pfIsolationVariables().sumChargedHadronPt
         elif R == 0.4: return self.physObj.chargedHadronIso()
         raise RuntimeError, "Electron chargedHadronIso missing for R=%s" % R
 
     def neutralHadronIsoR(self,R=0.4):
-        if   R == 0.3: return self.physObj.pfIsolationVariables().sumNeutralHadronEt 
+        if   R == 0.3: return self.physObj.pfIsolationVariables().sumNeutralHadronEt
         elif R == 0.4: return self.physObj.neutralHadronIso()
         raise RuntimeError, "Electron neutralHadronIso missing for R=%s" % R
 
     def photonIsoR(self,R=0.4):
-        if   R == 0.3: return self.physObj.pfIsolationVariables().sumPhotonEt 
+        if   R == 0.3: return self.physObj.pfIsolationVariables().sumPhotonEt
         elif R == 0.4: return self.physObj.photonIso()
         raise RuntimeError, "Electron photonIso missing for R=%s" % R
 
     def chargedAllIsoR(self,R=0.4):
-        if   R == 0.3: return self.physObj.pfIsolationVariables().sumChargedParticlePt 
+        if   R == 0.3: return self.physObj.pfIsolationVariables().sumChargedParticlePt
         raise RuntimeError, "Electron chargedAllIso missing for R=%s" % R
 
     def chargedAllIso(self):
         raise RuntimeError, "Electron chargedAllIso missing"
 
     def puChargedHadronIsoR(self,R=0.4):
-        if   R == 0.3: return self.physObj.pfIsolationVariables().sumPUPt 
+        if   R == 0.3: return self.physObj.pfIsolationVariables().sumPUPt
         elif R == 0.4: return self.physObj.puChargedHadronIso()
         raise RuntimeError, "Electron chargedHadronIso missing for R=%s" % R
 
@@ -167,8 +223,8 @@ class Electron( Lepton ):
         if vertex is None:
             vertex = self.associatedVertex
         return self.gsfTrack().dxy( vertex.position() )
-    def p4(self):	
-	 return ROOT.reco.Candidate.p4(self.physObj) 
+    def p4(self):
+	 return ROOT.reco.Candidate.p4(self.physObj)
 
 #    def p4(self):
 #        return self.physObj.p4(self.physObj.candidateP4Kind()) # if kind == None else kind)
@@ -185,6 +241,6 @@ class Electron( Lepton ):
     def lostInner(self) :
         if hasattr(self.gsfTrack(),"trackerExpectedHitsInner") :
 		return self.gsfTrack().trackerExpectedHitsInner().numberOfLostHits()
-	else :	
-		return self.gsfTrack().hitPattern().numberOfHits(ROOT.reco.HitPattern.MISSING_INNER_HITS)	
+	else :
+		return self.gsfTrack().hitPattern().numberOfHits(ROOT.reco.HitPattern.MISSING_INNER_HITS)
 

--- a/PhysicsTools/Heppy/python/physicsutils/ElectronMVAID.py
+++ b/PhysicsTools/Heppy/python/physicsutils/ElectronMVAID.py
@@ -4,18 +4,19 @@ import ROOT
 class ElectronMVAID:
     def __init__(self,name,type,*xmls):
         self.name = name
-        self.estimator = ROOT.heppy.EGammaMvaEleEstimatorFWLite()
+        self.estimator = ROOT.heppy.EGammaMvaEleEstimatorFWLite() 
         self.sxmls = ROOT.vector(ROOT.string)()
         for x in xmls: self.sxmls.push_back(x)  
         self.etype = -1
         if type == "Trig":     self.etype = self.estimator.kTrig;
         if type == "NonTrig":  self.etype = self.estimator.kNonTrig;
         if type == "TrigNoIP": self.etype = self.estimator.kTrigNoIP;
+        if type == "TrigCSA14":     self.etype = self.estimator.kTrigCSA14;
+        if type == "NonTrigCSA14":  self.etype = self.estimator.kNonTrigCSA14;
+        if type == "NonTrigPhys14":  self.etype = self.estimator.kNonTrigPhys14;
         if self.etype == -1: raise RuntimeError, "Unknown type %s" % type
         self._init = False
     def __call__(self,ele,vtx,rho,full5x5=False,debug=False):
-#FIXME:
-	return -99
         if not self._init:
             self.estimator.initialize(self.name,self.etype,True,self.sxmls)
             self._init = True
@@ -45,3 +46,45 @@ ElectronMVAID_TrigNoIP = ElectronMVAID("BDT", "TrigNoIP",
         "EgammaAnalysis/ElectronTools/data/Electrons_BDTG_TrigNoIPV0_2012_Cat5.weights.xml.gz",
         "EgammaAnalysis/ElectronTools/data/Electrons_BDTG_TrigNoIPV0_2012_Cat6.weights.xml.gz",
 )
+
+ElectronMVAID_TrigCSA14bx50 = ElectronMVAID("BDT", "TrigCSA14", 
+        "EgammaAnalysis/ElectronTools/data/CSA14/TrigIDMVA_50ns_EB_BDT.weights.xml.gz",
+        "EgammaAnalysis/ElectronTools/data/CSA14/TrigIDMVA_50ns_EE_BDT.weights.xml.gz",
+)
+ElectronMVAID_TrigCSA14bx25 = ElectronMVAID("BDT", "TrigCSA14", 
+        "EgammaAnalysis/ElectronTools/data/CSA14/TrigIDMVA_25ns_EB_BDT.weights.xml.gz",
+        "EgammaAnalysis/ElectronTools/data/CSA14/TrigIDMVA_25ns_EE_BDT.weights.xml.gz",
+)
+
+ElectronMVAID_NonTrigCSA14bx25 = ElectronMVAID("BDT", "NonTrigCSA14", 
+        "EgammaAnalysis/ElectronTools/data/CSA14/EIDmva_EB_5_25ns_BDT.weights.xml.gz",
+        "EgammaAnalysis/ElectronTools/data/CSA14/EIDmva_EE_5_25ns_BDT.weights.xml.gz",
+        "EgammaAnalysis/ElectronTools/data/CSA14/EIDmva_EB_10_25ns_BDT.weights.xml.gz",
+        "EgammaAnalysis/ElectronTools/data/CSA14/EIDmva_EE_10_25ns_BDT.weights.xml.gz",
+)
+ElectronMVAID_NonTrigCSA14bx50 = ElectronMVAID("BDT", "NonTrigCSA14", 
+        "EgammaAnalysis/ElectronTools/data/CSA14/EIDmva_EB_5_50ns_BDT.weights.xml.gz",
+        "EgammaAnalysis/ElectronTools/data/CSA14/EIDmva_EE_5_50ns_BDT.weights.xml.gz",
+        "EgammaAnalysis/ElectronTools/data/CSA14/EIDmva_EB_10_50ns_BDT.weights.xml.gz",
+        "EgammaAnalysis/ElectronTools/data/CSA14/EIDmva_EE_10_50ns_BDT.weights.xml.gz",
+)
+
+ElectronMVAID_NonTrigPhys14 = ElectronMVAID("BDT", "NonTrigPhys14", 
+        "EgammaAnalysis/ElectronTools/data/PHYS14/EIDmva_EB1_5_oldscenario2phys14_BDT.weights.xml.gz",
+        "EgammaAnalysis/ElectronTools/data/PHYS14/EIDmva_EB2_5_oldscenario2phys14_BDT.weights.xml.gz",
+        "EgammaAnalysis/ElectronTools/data/PHYS14/EIDmva_EE_5_oldscenario2phys14_BDT.weights.xml.gz",
+        "EgammaAnalysis/ElectronTools/data/PHYS14/EIDmva_EB1_10_oldscenario2phys14_BDT.weights.xml.gz",
+        "EgammaAnalysis/ElectronTools/data/PHYS14/EIDmva_EB2_10_oldscenario2phys14_BDT.weights.xml.gz",
+        "EgammaAnalysis/ElectronTools/data/PHYS14/EIDmva_EE_10_oldscenario2phys14_BDT.weights.xml.gz",
+)
+
+ElectronMVAID_ByName = {
+    'Trig':ElectronMVAID_Trig,
+    'NonTrig':ElectronMVAID_NonTrig,
+    'TrigNoIP':ElectronMVAID_TrigNoIP,
+    'TrigCSA14bx50':ElectronMVAID_TrigCSA14bx50,
+    'TrigCSA14bx25':ElectronMVAID_TrigCSA14bx25,
+    'NonTrigCSA14bx25':ElectronMVAID_NonTrigCSA14bx25,
+    'NonTrigCSA14bx50':ElectronMVAID_NonTrigCSA14bx50,
+    'NonTrigPhys14':ElectronMVAID_NonTrigPhys14,
+}

--- a/PhysicsTools/Heppy/src/EGammaMvaEleEstimatorFWLite.cc
+++ b/PhysicsTools/Heppy/src/EGammaMvaEleEstimatorFWLite.cc
@@ -1,18 +1,21 @@
 
 #include "PhysicsTools/Heppy/interface/EGammaMvaEleEstimatorFWLite.h"
 #include "EgammaAnalysis/ElectronTools/interface/EGammaMvaEleEstimator.h"
+#include "EgammaAnalysis/ElectronTools/interface/EGammaMvaEleEstimatorCSA14.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 
 namespace heppy {
 
 EGammaMvaEleEstimatorFWLite::EGammaMvaEleEstimatorFWLite() :
-    estimator_(0)
+    estimator_(0),
+    estimatorCSA14_(0)
 {
 }
 
 EGammaMvaEleEstimatorFWLite::~EGammaMvaEleEstimatorFWLite()
 {
     delete estimator_;
+    delete estimatorCSA14_;
 }
 
 void EGammaMvaEleEstimatorFWLite::initialize( std::string methodName,
@@ -20,20 +23,40 @@ void EGammaMvaEleEstimatorFWLite::initialize( std::string methodName,
         bool useBinnedVersion,
         std::vector<std::string> weightsfiles ) 
 {
-    EGammaMvaEleEstimator::MVAType pogType;
-    switch(type) {
-        case EGammaMvaEleEstimatorFWLite::kTrig: pogType = EGammaMvaEleEstimator::kTrig; break;
-        case EGammaMvaEleEstimatorFWLite::kTrigNoIP: pogType = EGammaMvaEleEstimator::kTrigNoIP; break;
-        case EGammaMvaEleEstimatorFWLite::kNonTrig: pogType = EGammaMvaEleEstimator::kNonTrig; break;
-        default:
-            return;
-    }
-    estimator_ = new EGammaMvaEleEstimator();
+    delete estimator_; estimator_ = 0;
+    delete estimatorCSA14_; estimatorCSA14_ = 0;
     std::vector<std::string> weightspaths;
     for (const std::string &s : weightsfiles) {
         weightspaths.push_back( edm::FileInPath(s).fullPath() );
     }
-    estimator_->initialize(methodName, pogType, useBinnedVersion, weightspaths);
+    switch(type) {
+        case EGammaMvaEleEstimatorFWLite::kTrig: 
+            estimator_ = new EGammaMvaEleEstimator();
+            estimator_->initialize(methodName, EGammaMvaEleEstimator::kTrig, useBinnedVersion, weightspaths);
+            break;
+        case EGammaMvaEleEstimatorFWLite::kTrigNoIP:
+            estimator_ = new EGammaMvaEleEstimator();
+            estimator_->initialize(methodName, EGammaMvaEleEstimator::kTrigNoIP, useBinnedVersion, weightspaths);
+            break;
+        case EGammaMvaEleEstimatorFWLite::kNonTrig:
+            estimator_ = new EGammaMvaEleEstimator();
+            estimator_->initialize(methodName, EGammaMvaEleEstimator::kNonTrig, useBinnedVersion, weightspaths);
+            break;
+        case EGammaMvaEleEstimatorFWLite::kTrigCSA14:
+            estimatorCSA14_ = new EGammaMvaEleEstimatorCSA14();
+            estimatorCSA14_->initialize(methodName, EGammaMvaEleEstimatorCSA14::kTrig, useBinnedVersion, weightspaths);
+            break;
+        case EGammaMvaEleEstimatorFWLite::kNonTrigCSA14:
+            estimatorCSA14_ = new EGammaMvaEleEstimatorCSA14();
+            estimatorCSA14_->initialize(methodName, EGammaMvaEleEstimatorCSA14::kNonTrig, useBinnedVersion, weightspaths);
+            break;
+        case EGammaMvaEleEstimatorFWLite::kNonTrigPhys14:
+            estimatorCSA14_ = new EGammaMvaEleEstimatorCSA14();
+            estimatorCSA14_->initialize(methodName, EGammaMvaEleEstimatorCSA14::kNonTrigPhys14, useBinnedVersion, weightspaths);
+            break;
+        default:
+            return;
+    }
 }
 
 float EGammaMvaEleEstimatorFWLite::mvaValue(const pat::Electron& ele,
@@ -42,9 +65,9 @@ float EGammaMvaEleEstimatorFWLite::mvaValue(const pat::Electron& ele,
                 bool full5x5,
                 bool printDebug)
 {
-  return -1.;
-//FIXME
-//    return estimator_->mvaValue(ele,vertex,rho,full5x5,printDebug);
+    if (estimator_) return estimator_->mvaValue(ele,vertex,rho,full5x5,printDebug);
+    else if (estimatorCSA14_) return estimatorCSA14_->mvaValue(ele,printDebug);
+    else throw cms::Exception("LogicError", "You must call unitialize before mvaValue\n");
 }
 
 }

--- a/PhysicsTools/Heppy/src/Megajet.cc
+++ b/PhysicsTools/Heppy/src/Megajet.cc
@@ -1,0 +1,225 @@
+#include "PhysicsTools/Heppy/interface/Megajet.h"
+
+#include <vector>
+#include <math.h>
+#include <TLorentzVector.h>
+
+using namespace std;
+
+namespace heppy {
+
+// constructor specifying the association methods
+Megajet::Megajet(vector<float> Px_vector, vector<float> Py_vector, vector<float> Pz_vector,
+                 vector<float> E_vector, int megajet_association_method) : 
+  Object_Px(Px_vector), Object_Py(Py_vector), Object_Pz(Pz_vector), Object_E(E_vector), 
+  megajet_meth(megajet_association_method),  status(0) { 
+
+  if(Object_Px.size() < 2) cout << "Error in Megajet: you should provide at least two jets to form Megajets" << endl;
+  for(int j=0; j<(int)jIN.size(); ++j) {
+    jIN.push_back(TLorentzVector(Object_Px[j],Object_Py[j],Object_Pz[j],Object_E[j]));
+  }
+}
+
+// constructor without specification of the seed and association methods
+// in this case, the latter must be given by calling SetMethod before invoking Combine()
+Megajet::Megajet(vector<float> Px_vector, vector<float> Py_vector, vector<float> Pz_vector,
+                 vector<float> E_vector) : 
+  Object_Px(Px_vector), Object_Py(Py_vector), Object_Pz(Pz_vector), Object_E(E_vector), 
+  status(0) { 
+
+  if(Object_Px.size() < 2) cout << "Error in Megajet: you should provide at least two jets to form Megajets" << endl;
+  for(int j=0; j<(int)jIN.size(); ++j) {
+    jIN.push_back(TLorentzVector(Object_Px[j],Object_Py[j],Object_Pz[j],Object_E[j]));
+  }
+}
+
+vector<float> Megajet::getAxis1(){
+  if (status != 1) {
+    this->Combine();
+    if( megajet_meth == 1) this->CombineMinMass();
+    else if(megajet_meth == 2) this->CombineMinHT();
+    else if(megajet_meth == 3) this->CombineMinEnergyMass();
+    else if(megajet_meth == 4) this->CombineGeorgi();
+    else this->CombineMinMass();
+  }
+  if(jIN.size() > 1) {
+    Axis1[0] = jOUT[0].Px() / jOUT[0].P();
+    Axis1[1] = jOUT[0].Py() / jOUT[0].P();
+    Axis1[2] = jOUT[0].Pz() / jOUT[0].P();
+    Axis1[3] = jOUT[0].P();
+    Axis1[4] = jOUT[0].E();
+  }
+  return Axis1;
+}
+vector<float> Megajet::getAxis2(){
+  if (status != 1) {
+    this->Combine();
+    if( megajet_meth == 1) this->CombineMinMass();
+    else if(megajet_meth == 2) this->CombineMinHT();
+    else if(megajet_meth == 3) this->CombineMinEnergyMass();
+    else if(megajet_meth == 4) this->CombineGeorgi();
+    else this->CombineMinMass();
+  }
+  if(jIN.size() > 1) {
+    Axis2[0] = jOUT[1].Px() / jOUT[1].P();
+    Axis2[1] = jOUT[1].Py() / jOUT[1].P();
+    Axis2[2] = jOUT[1].Pz() / jOUT[1].P();
+    Axis2[3] = jOUT[1].P();
+    Axis2[4] = jOUT[1].E();
+  }
+  return Axis2;
+}
+
+void Megajet::Combine() {
+  int N_JETS = (int)jIN.size();
+
+  int N_comb = 1;
+  for(int i = 0; i < N_JETS; i++){
+    N_comb *= 2;
+  }
+    
+  // clear some vectors if method Combine() is called again
+  if ( !j1.empty() ) {
+    j1.clear();
+    j2.clear();
+    Axis1.clear();
+    Axis2.clear();
+  }
+
+  for(int j = 0; j < 5; ++j){
+    Axis1.push_back(0);
+    Axis2.push_back(0);
+  }
+
+  int j_count;
+  for(int i = 1; i < N_comb-1; i++){
+    TLorentzVector j_temp1, j_temp2;
+    int itemp = i;
+    j_count = N_comb/2;
+    int count = 0;
+    while(j_count > 0){
+      if(itemp/j_count == 1){
+	j_temp1 += jIN[count];
+      } else {
+	j_temp2 += jIN[count];
+      }
+      itemp -= j_count*(itemp/j_count);
+      j_count /= 2;
+      count++;
+    }
+
+    j1.push_back(j_temp1);
+    j2.push_back(j_temp2);
+  }
+}
+
+void Megajet::CombineMinMass() {
+  double M_min = -1;
+  // default value (in case none is found)
+  TLorentzVector myJ1 = TLorentzVector(0,0,0,0);
+  TLorentzVector myJ2 = TLorentzVector(0,0,0,0);
+  for(int i=0; i<(int)j1.size(); i++) {
+    double M_temp = j1[i].M2()+j2[i].M2();
+    if(M_min < 0 || M_temp < M_min){
+      M_min = M_temp;
+      myJ1 = j1[i];
+      myJ2 = j2[i];
+    }
+  }
+  //  myJ1.SetPtEtaPhiM(myJ1.Pt(),myJ1.Eta(),myJ1.Phi(),0.0);
+  //  myJ2.SetPtEtaPhiM(myJ2.Pt(),myJ2.Eta(),myJ2.Phi(),0.0);
+
+  jOUT.clear();
+  if(myJ1.Pt() > myJ2.Pt()){
+    jOUT.push_back(myJ1);
+    jOUT.push_back(myJ2);
+  } else {
+    jOUT.push_back(myJ2);
+    jOUT.push_back(myJ1);
+  }
+  status=1;
+}
+
+void Megajet::CombineMinEnergyMass() {
+  double M_min = -1;
+  // default value (in case none is found)
+  TLorentzVector myJ1 = TLorentzVector(0,0,0,0);
+  TLorentzVector myJ2 = TLorentzVector(0,0,0,0);
+  for(int i=0; i<(int)j1.size(); i++) {
+    double M_temp = j1[i].M2()/j1[i].E()+j2[i].M2()/j2[i].E();
+    if(M_min < 0 || M_temp < M_min){
+      M_min = M_temp;
+      myJ1 = j1[i];
+      myJ2 = j2[i];
+    }
+  }
+  
+  //  myJ1.SetPtEtaPhiM(myJ1.Pt(),myJ1.Eta(),myJ1.Phi(),0.0);
+  //  myJ2.SetPtEtaPhiM(myJ2.Pt(),myJ2.Eta(),myJ2.Phi(),0.0);
+
+  jOUT.clear();
+  if(myJ1.Pt() > myJ2.Pt()){
+    jOUT.push_back(myJ1);
+    jOUT.push_back(myJ2);
+  } else {
+    jOUT.push_back(myJ2);
+    jOUT.push_back(myJ1);
+  }
+  status=1;
+}
+
+void Megajet::CombineGeorgi(){
+  double M_max = -10000;
+  // default value (in case none is found)
+  TLorentzVector myJ1 = TLorentzVector(0,0,0,0);
+  TLorentzVector myJ2 = TLorentzVector(0,0,0,0);
+  for(int i=0; i<(int)j1.size(); i++) {
+    int myBeta = 2;
+    double M_temp = (j1[i].E()-myBeta*j1[i].M2()/j1[i].E())+(j2[i].E()-myBeta*j2[i].M2()/j2[i].E());
+    if(M_max < -9999 || M_temp > M_max){
+      M_max = M_temp;
+      myJ1 = j1[i];
+      myJ2 = j2[i];
+    }
+  }
+  
+  //  myJ1.SetPtEtaPhiM(myJ1.Pt(),myJ1.Eta(),myJ1.Phi(),0.0);
+  //  myJ2.SetPtEtaPhiM(myJ2.Pt(),myJ2.Eta(),myJ2.Phi(),0.0);
+
+  jOUT.clear();
+  if(myJ1.Pt() > myJ2.Pt()){
+    jOUT.push_back(myJ1);
+    jOUT.push_back(myJ2);
+  } else {
+    jOUT.push_back(myJ2);
+    jOUT.push_back(myJ1);
+  }
+  status=1;
+}
+
+void Megajet::CombineMinHT() {
+  double dHT_min = 999999999999999.0;
+  // default value (in case none is found)
+  TLorentzVector myJ1 = TLorentzVector(0,0,0,0);
+  TLorentzVector myJ2 = TLorentzVector(0,0,0,0);
+  for(int i=0; i<(int)j1.size(); i++) {
+    double dHT_temp = fabs(j1[i].E()-j2[i].E());
+    if(dHT_temp < dHT_min){  
+      dHT_min = dHT_temp;
+      myJ1 = j1[i];
+      myJ2 = j2[i];
+    }
+  }
+  
+  jOUT.clear();
+  if(myJ1.Pt() > myJ2.Pt()){
+    jOUT.push_back(myJ1);
+    jOUT.push_back(myJ2);
+  } else {
+    jOUT.push_back(myJ2);
+    jOUT.push_back(myJ1);
+  }
+  status=1;
+}
+
+}

--- a/PhysicsTools/Heppy/src/classes.h
+++ b/PhysicsTools/Heppy/src/classes.h
@@ -11,6 +11,7 @@
 #include "PhysicsTools/Heppy/interface/Hemisphere.h"
 #include "PhysicsTools/Heppy/interface/AlphaT.h"
 #include "PhysicsTools/Heppy/interface/Apc.h"
+#include "PhysicsTools/Heppy/interface/Megajet.h"
 #include "PhysicsTools/Heppy/interface/ReclusterJets.h"
 #include "PhysicsTools/Heppy/interface/IsolationComputer.h"
 
@@ -37,6 +38,7 @@ namespace {
     heppy::mt2w_bisect::mt2w mt2wlept;
     heppy::AlphaT alphaT;
     heppy::Apc apc;
+    heppy::Megajet megajet;
     heppy::ReclusterJets reclusterJets(std::vector<float> px, std::vector<float> py, std::vector<float> pz, std::vector<float> E, double ktpower, double rparam);
     //  heppy::SimpleElectron fuffaElectron;
     //  ElectronEnergyCalibrator fuffaElectronCalibrator;

--- a/PhysicsTools/Heppy/src/classes_def.xml
+++ b/PhysicsTools/Heppy/src/classes_def.xml
@@ -12,6 +12,7 @@
   <class name="heppy::EGammaMvaEleEstimatorFWLite" transient="true" />
   <class name="heppy::AlphaT" transient="true" />
   <class name="heppy::Apc" transient="true" />
+  <class name="heppy::Megajet" transient="true" />
   <class name="heppy::ReclusterJets"  transient="true"/>
   <class name="heppy::IsolationComputer"  transient="true"/>
 


### PR DESCRIPTION
@cbernet @gpetruc @arizzi: There are two commits here:
- the first adds the capability to use the new electron IDs (CSA14 and PHYS14 cut based and MVAs) in 7.4.0
  For the first one to run properly, one should modify the EgammaAnalysis/ElectronTools as it is done in the CMG cmssw branch. Let me know if I should also commit this (but probably it requires coordination with e-gamma people: how it was handled until 7.2.3?)
- the second adds back the calculation of megajets that were skipped in the last branch of Colin
