### PR TITLE
improved file name checking in Chain

### DIFF
--- a/PhysicsTools/HeppyCore/python/framework/chain.py
+++ b/PhysicsTools/HeppyCore/python/framework/chain.py
@@ -6,6 +6,18 @@ import os
 import pprint
 from ROOT import TChain, TFile, TTree, gSystem
 
+def is_pfn(fn):
+    return not is_lfn(fn)
+
+def is_lfn(fn):
+    return fn.startswith("/store")
+
+def is_rootfn(fn):
+    """
+    To open files like root://, file:// which os.isfile won't find.
+    """
+    return "://" in fn
+
 class Chain( object ):
     """Wrapper to TChain, with a python iterable interface.
 
@@ -37,7 +49,10 @@ class Chain( object ):
             if len(self.files)==0:
                 raise ValueError('no matching file name: '+input)
         else: # case of a list of files
-            if False in [ os.path.isfile(fnam) for fnam in self.files ]:
+            if False in [
+                ((is_pfn(fnam) and os.path.isfile(fnam)) or
+                is_lfn(fnam)) or is_rootfn(fnam)
+                for fnam in self.files]:
                 err = 'at least one input file does not exist\n'
                 err += pprint.pformat(self.files)
                 raise ValueError(err)


### PR DESCRIPTION
Supersedes PR #28. Needed to use Heppy and Chain for analysis of files which are located in storage in T3_PSI_CH which must be opened through `TFile::Open("root://...")`
