### PR TITLE
Heppy 7 4 5 allow batch at cern to write to eos mdg

### DIFF
--- a/PhysicsTools/Heppy/python/physicsutils/BTagWeightCalculator.py
+++ b/PhysicsTools/Heppy/python/physicsutils/BTagWeightCalculator.py
@@ -11,7 +11,7 @@ class BTagWeightCalculator:
         self.pt_bins_lf = np.array([20, 30, 40, 60, 10000])
         self.eta_bins_lf = np.array([0, 0.8, 1.6, 2.41])
 
-        self.btag = "combinedInclusiveSecondaryVertexV2BJetTags"
+        self.btag = "pfCombinedInclusiveSecondaryVertexV2BJetTags"
         self.init(fn_hf, fn_lf)
 
     def getBin(self, bvec, val):

--- a/PhysicsTools/HeppyCore/scripts/heppy_batch.py
+++ b/PhysicsTools/HeppyCore/scripts/heppy_batch.py
@@ -82,18 +82,22 @@ if [ $? -ne 0 ]; then
 else
    echo 'job directory copy succeeded'
 fi"""
+
    if remoteDir=='':
       cpCmd=dirCopy
-   elif remoteDir.startswith("/pnfs/psi.ch"):
+   elif 'cmst3' in remoteDir:
        cpCmd="""echo 'sending root files to remote dir'
-export LD_LIBRARY_PATH=/usr/lib64:$LD_LIBRARY_PATH # Fabio's workaround to fix gfal-tools with CMSSW
-for f in Loop/mt2*.root
+export LD_LIBRARY_PATH=/usr/lib64:$LD_LIBRARY_PATH # 
+for f in Loop/tree*.root
 do
    ff=`basename $f | cut -d . -f 1`
-   #d=`echo $f | cut -d / -f 2`
-   gfal-mkdir {srm}
-   echo "gfal-copy file://`pwd`/Loop/$ff.root {srm}/${{ff}}_{idx}.root"
+   echo $f
+   echo $ff
+   export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
+   source $VO_CMS_SW_DIR/cmsset_default.sh
+   echo "gfal-copy file://`pwd`/Loop/$ff.root {srm}/${{ff}}_{idx}.root" 
    gfal-copy file://`pwd`/Loop/$ff.root {srm}/${{ff}}_{idx}.root
+   echo $idx 
    if [ $? -ne 0 ]; then
       echo "ERROR: remote copy failed for file $ff"
    else
@@ -102,10 +106,10 @@ do
    fi
 done
 #fi
-""".format(idx=jobDir[jobDir.find("_Chunk")+6:].strip("/"), srm='srm://t3se01.psi.ch'+remoteDir+jobDir[jobDir.rfind("/"):jobDir.find("_Chunk")]) + dirCopy
+""".format(idx=jobDir[jobDir.find("_Chunk")+6:].strip("/"),  srm=""+remoteDir+jobDir[jobDir.rfind("/"):jobDir.find("_Chunk")])
    else:
        print "chosen location not supported yet: ", remoteDir
-       print 'path must start with "/pnfs/psi.ch"'
+       print 'path must contain cmst3"'
        sys.exit(1)
 
    script = """#!/bin/bash


### PR DESCRIPTION
one can now write to cmst3 (if splitFactor >1) with the batch commands something like

heppy_batch.py -r /store/group/cmst3/user/username/dirname -o dirname  heppyanalysis.py  batch LXPLUS  -b 'bsub -q blahblahblah < batchScript.sh'
