### PR TITLE
save original gen-jet index

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
@@ -113,6 +113,8 @@ class JetAnalyzer( Analyzer ):
 
         if self.cfg_comp.isMC:
             self.genJets = [ x for x in self.handles['genJet'].product() ]
+            for igj, gj in enumerate(self.genJets):
+                gj.index = igj
             self.matchJets(event, allJets)
             if getattr(self.cfg_ana, 'smearJets', False):
                 self.smearJets(event, allJets)


### PR DESCRIPTION
We need to be able to correlate gen-jets with their original indices for the GenHFHadronMatcher module. See also https://github.com/vhbb/cmssw/pull/156
@arizzi
