### PR TITLE
Dev heppy flexible preprocessor

### DIFF
--- a/PhysicsTools/Heppy/python/utils/cmsswPreprocessor.py
+++ b/PhysicsTools/Heppy/python/utils/cmsswPreprocessor.py
@@ -1,22 +1,47 @@
-import os                                                               
+import os 
+import sys                                                              
 import re 
 import imp
 from PhysicsTools.HeppyCore.framework.config import CFG
 class CmsswPreprocessor :
-	def __init__(self,configFile,command="cmsRun") :
+	def __init__(self,configFile,command="cmsRun",options={}) :
 		self.configFile=configFile
 		self.command=command
+                self.options=options
 	
 	def run(self,component,wd,firstEvent,nEvents):
 		print wd,firstEvent,nEvents
 		if nEvents is None:
 			nEvents = -1
-		cmsswConfig = imp.load_source("cmsRunProcess",self.configFile)
+
+                cmsswConfig = imp.load_source("cmsRunProcess",self.configFile)
 		inputfiles= []
 		for fn in component.files :
 			if not re.match("file:.*",fn) and not re.match("root:.*",fn) :
 				fn="file:"+fn
 			inputfiles.append(fn)
+
+                # Four cases: 
+                # - no options, cmsswConfig with initialize function
+                #     run initialize with default parameters
+                # - filled options, cmsswConfig with initialize function
+                #     pass on options to initialize
+                # - no options, classic cmsswConfig
+                #     legacy mode
+                # - filled options, classic cmsswConfig
+                #     legacy mode but warn that options are not passed on
+
+                if hasattr(cmsswConfig, "initialize"):
+                        if len(self.options) == 0:                                
+                                cmsswConfig.process = cmsswConfig.initialize()                                 
+                        else:                                
+                                cmsswConfig.process = cmsswConfig.initialize(**self.options)                                 
+                else:
+                        if len(self.options) == 0:                             
+                                pass
+                        else:
+                                print "WARNING: cmsswPreprocessor received options but can't pass on to cmsswConfig"
+                
 		cmsswConfig.process.source.fileNames = inputfiles
 		cmsswConfig.process.maxEvents.input=nEvents
 		#fixme: implement skipEvent / firstevent


### PR DESCRIPTION
This commit makes the preprocessor more flexible. The CMSSW config can now either be a "standard file" - then everything works as before 
OR
it can contain a function called "initialize" that return the "process" object. The function can have arbitrary arguments (but each needs a default value). 

If the second approach is chosen then a dictionary named "options" can be passed when creating the "CmsswPreprocessor" object. This dictionary is then passed on to the intialize function. 

Example config file:
https://github.com/gkasieczka/cmssw/blob/f6da05df6b8203a93046396a6fd321c92572355f/VHbbAnalysis/Heppy/test/combined_cmssw.py#L26
