### PR TITLE
Several Jet related fixes and features from VHbb 

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
@@ -2,7 +2,7 @@ import math, os
 from PhysicsTools.Heppy.analyzers.core.Analyzer import Analyzer
 from PhysicsTools.Heppy.analyzers.core.AutoHandle import AutoHandle
 from PhysicsTools.Heppy.physicsobjects.PhysicsObjects import Jet
-from PhysicsTools.HeppyCore.utils.deltar import deltaR2, deltaPhi, matchObjectCollection, matchObjectCollection2, bestMatch
+from PhysicsTools.HeppyCore.utils.deltar import deltaR2, deltaPhi, matchObjectCollection, matchObjectCollection2, bestMatch,matchObjectCollection3
 from PhysicsTools.Heppy.physicsutils.JetReCalibrator import JetReCalibrator
 import PhysicsTools.HeppyCore.framework.config as cfg
 
@@ -102,6 +102,10 @@ class JetAnalyzer( Analyzer ):
           allJets = map(lambda j:Jet(ROOT.pat.Jet(ROOT.edm.Ptr(ROOT.pat.Jet)(ROOT.edm.ProductID(),j,0))), self.handles['jets'].product()) #copy-by-value is safe if JetAnalyzer is ran more than once
         else: 
           allJets = map(Jet, self.handles['jets'].product()) 
+       
+        #set dummy MC flavour for all jets in case we want to ntuplize discarded jets later
+        for jet in allJets:
+            jet.mcFlavour = 0
 
         self.deltaMetFromJEC = [0.,0.]
 #        print "before. rho",self.rho,self.cfg_ana.collectionPostFix,'allJets len ',len(allJets),'pt', [j.pt() for j in allJets]
@@ -121,22 +125,42 @@ class JetAnalyzer( Analyzer ):
         
 	##Sort Jets by pT 
         allJets.sort(key = lambda j : j.pt(), reverse = True)
+        
+        leptons = []
+        if hasattr(event, 'selectedLeptons'):
+            leptons = [ l for l in event.selectedLeptons if l.pt() > self.lepPtMin and self.lepSelCut(l) ]
+        if self.cfg_ana.cleanJetsFromTaus and hasattr(event, 'selectedTaus'):
+            leptons = leptons[:] + event.selectedTaus
+        if self.cfg_ana.cleanJetsFromIsoTracks and hasattr(event, 'selectedIsoCleanTrack'):
+            leptons = leptons[:] + event.selectedIsoCleanTrack
+
 	## Apply jet selection
         self.jets = []
         self.jetsFailId = []
         self.jetsAllNoID = []
         self.jetsIdOnly = []
         for jet in allJets:
+            #Check if lepton and jet have overlapping PF candidates 
+            leps_with_overlaps = []
+            for i in range(jet.numberOfSourceCandidatePtrs()):
+                p1 = jet.sourceCandidatePtr(i) #Ptr<Candidate> p1
+                for lep in leptons:
+                    for j in range(lep.numberOfSourceCandidatePtrs()):
+                        p2 = lep.sourceCandidatePtr(j)
+                        has_overlaps = p1.key() == p2.key() and p1.refCore().id().productIndex() == p2.refCore().id().productIndex() and p1.refCore().id().processIndex() == p2.refCore().id().processIndex()
+                        if has_overlaps:
+                            leps_with_overlaps += [lep]
+            if len(leps_with_overlaps)>0:
+                for lep in leps_with_overlaps:
+                    lep.jetOverlap = jet
             if self.testJetNoID( jet ): 
                 self.jetsAllNoID.append(jet) 
+                if(self.cfg_ana.doQG):
+                    jet.qgl_calc =  self.qglcalc.computeQGLikelihood
+                    jet.qgl_rho =  rho
                 # temporary fix since the jetID it's not good for eta>3
                 if abs(jet.eta()) <3:
                     if self.testJetID (jet ):
-
-                        if(self.cfg_ana.doQG):
-                            jet.qgl_calc =  self.qglcalc.computeQGLikelihood
-                            jet.qgl_rho =  rho
-
                         self.jets.append(jet)
                         self.jetsIdOnly.append(jet)
                     else:
@@ -146,26 +170,30 @@ class JetAnalyzer( Analyzer ):
             elif self.testJetID (jet ):
                 self.jetsIdOnly.append(jet)
 
-        ## Clean Jets from leptons
-        leptons = []
-        if hasattr(event, 'selectedLeptons'):
-            leptons = [ l for l in event.selectedLeptons if l.pt() > self.lepPtMin and self.lepSelCut(l) ]
+        jetsEtaCut = [j for j in self.jets if abs(j.eta()) <  self.cfg_ana.jetEta ]
+        self.cleanJetsAll, cleanLeptons = cleanJetsAndLeptons(jetsEtaCut, leptons, self.jetLepDR, self.jetLepArbitration)
+
+        self.cleanJets    = [j for j in self.cleanJetsAll if abs(j.eta()) <  self.cfg_ana.jetEtaCentral ]
+        self.cleanJetsFwd = [j for j in self.cleanJetsAll if abs(j.eta()) >= self.cfg_ana.jetEtaCentral ]
+        self.discardedJets = [j for j in allJets if j not in self.cleanJetsAll]
+        if hasattr(event, 'selectedLeptons') and self.cfg_ana.cleanSelectedLeptons:
+            event.discardedLeptons = [ l for l in leptons if l not in cleanLeptons ]
+            event.selectedLeptons  = [ l for l in event.selectedLeptons if l not in event.discardedLeptons ]
+        for lep in leptons:
+            if hasattr(lep, "jetOverlap"):
+                if lep.jetOverlap in self.cleanJetsAll:
+                    #print "overlap reco", lep.p4().pt(), lep.p4().eta(), lep.p4().phi(), lep.jetOverlap.p4().pt(), lep.jetOverlap.p4().eta(), lep.jetOverlap.p4().phi()
+                    lep.jetOverlapIdx = self.cleanJetsAll.index(lep.jetOverlap)
+                elif lep.jetOverlap in self.discardedJets:
+                    #print "overlap discarded", lep.p4().pt(), lep.p4().eta(), lep.p4().phi(), lep.jetOverlap.p4().pt(), lep.jetOverlap.p4().eta(), lep.jetOverlap.p4().phi()
+                    lep.jetOverlapIdx = 1000 + self.discardedJets.index(lep.jetOverlap)
+
         if self.cfg_ana.cleanJetsFromTaus and hasattr(event, 'selectedTaus'):
             leptons = leptons[:] + event.selectedTaus
         if self.cfg_ana.cleanJetsFromIsoTracks and hasattr(event, 'selectedIsoCleanTrack'):
             leptons = leptons[:] + event.selectedIsoCleanTrack
-
-        jetsEtaCut = [j for j in self.jets if abs(j.eta()) <  self.cfg_ana.jetEta ]
-        self.cleanJetsAll, cleanLeptons = cleanJetsAndLeptons(jetsEtaCut, leptons, self.jetLepDR, self.jetLepArbitration)
-        #self.cleanJetsAll, cleanLeptons = cleanJetsAndLeptons(self.jets, leptons, self.jetLepDR, self.jetLepArbitration) ##from central
-        self.cleanJets    = [j for j in self.cleanJetsAll if abs(j.eta()) <  self.cfg_ana.jetEtaCentral ]
-        self.cleanJetsFwd = [j for j in self.cleanJetsAll if abs(j.eta()) >= self.cfg_ana.jetEtaCentral ]
-        self.discardedJets = [j for j in self.jets if j not in self.cleanJetsAll]
-        if hasattr(event, 'selectedLeptons') and self.cfg_ana.cleanSelectedLeptons:
-            event.discardedLeptons = [ l for l in leptons if l not in cleanLeptons ]
-            event.selectedLeptons  = [ l for l in event.selectedLeptons if l not in event.discardedLeptons ]
-
-        ## Clean Jets from photons
+        
+        # Clean Jets from photons
         photons = []
         if hasattr(event, 'selectedPhotons'):
             if self.cfg_ana.cleanJetsFromFirstPhoton:
@@ -183,14 +211,13 @@ class JetAnalyzer( Analyzer ):
             self.cleanJetsAll = self.gamma_cleanJetsAll
             self.cleanJetsFwd = self.gamma_cleanJetsFwd
 
-        ## Associate jets to leptons
-        leptons = event.inclusiveLeptons if hasattr(event, 'inclusiveLeptons') else event.selectedLeptons
-        jlpairs = matchObjectCollection( leptons, allJets, self.jetLepDR**2)
+        ## Associate jets to inclusive leptons
+        incleptons = event.inclusiveLeptons if hasattr(event, 'inclusiveLeptons') else event.selectedLeptons
+        jlpairs = matchObjectCollection( incleptons, allJets, self.jetLepDR**2)
 
         for jet in allJets:
             jet.leptons = [l for l in jlpairs if jlpairs[l] == jet ]
-
-        for lep in leptons:
+        for lep in incleptons:
             jet = jlpairs[lep]
             if jet is None:
                 setattr(lep,"jet"+self.cfg_ana.collectionPostFix,lep)
@@ -218,6 +245,17 @@ class JetAnalyzer( Analyzer ):
             if self.cfg_ana.cleanGenJetsFromPhoton:
                 self.cleanGenJets = cleanNearestJetOnly(self.cleanGenJets, photons, self.jetLepDR)
 
+	    if hasattr(self.cfg_ana,"genNuSelection") :
+		jetNus=[x for x in event.genParticles if abs(x.pdgId()) in [12,14,16] and self.cfg_ana.genNuSelection(x) ]
+	 	pairs= matchObjectCollection (jetNus, self.genJets, 0.4**2)
+                
+		for (nu,genJet) in pairs.iteritems() :
+		     if genJet is not None :
+			if not hasattr(genJet,"nu") :
+				genJet.nu=nu.p4()
+			else :
+				genJet.nu+=nu.p4()
+			
             
             #event.nGenJets25 = 0
             #event.nGenJets25Cen = 0
@@ -386,6 +424,7 @@ setattr(JetAnalyzer,"defaultConfig", cfg.Analyzer(
     jecPath = "",
     do_mc_match=True,
     cleanGenJetsFromPhoton = False,
+    genNuSelection = lambda nu : True, #FIXME: add here check for ispromptfinalstate
     collectionPostFix = ""
     )
 )

--- a/PhysicsTools/Heppy/python/physicsobjects/Jet.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Jet.py
@@ -133,7 +133,7 @@ class Jet(PhysicsObject):
               self.computeQGvars()
               self.qgl_value=self.qgl_calc(self,self.qgl_rho)
 	  else :
-              self.qgl_value=0. #if no qgl calculator configured
+              self.qgl_value=-1. #if no qgl calculator configured
 		  
        return self.qgl_value
 


### PR DESCRIPTION
@gpetruc  @cbernet 

This PR contains:
- neutrino recovery in gen Jets (w/o rerunning the clustering)
- jets / lepton overlap check based on PF ref (from @jpata)
- fix genCleanedJets ("leptons" collection had different meaning down there...avoid such change)
-  qgl run also for eta > 3
- qgl default to -1 (from @chernyavskaya )
