### PR TITLE
E/gamma calibration and smearing modules (76X)

### DIFF
--- a/EgammaAnalysis/ElectronTools/interface/EGammaMvaEleEstimatorCSA14.h
+++ b/EgammaAnalysis/ElectronTools/interface/EGammaMvaEleEstimatorCSA14.h
@@ -20,8 +20,6 @@
 #include "TMVA/Tools.h"
 #include "TMVA/Reader.h"
 
-using namespace std;
-
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
@@ -39,8 +37,6 @@ using namespace std;
 #include "DataFormats/Common/interface/RefToPtr.h"
 
 #include "DataFormats/PatCandidates/interface/Electron.h"
-
-using namespace reco;
 
 class EGammaMvaEleEstimatorCSA14{
   public:

--- a/EgammaAnalysis/ElectronTools/interface/EGammaMvaEleEstimatorCSA14.h
+++ b/EgammaAnalysis/ElectronTools/interface/EGammaMvaEleEstimatorCSA14.h
@@ -20,6 +20,7 @@
 #include "TMVA/Tools.h"
 #include "TMVA/Reader.h"
 
+using namespace std;
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
@@ -39,6 +40,7 @@
 
 #include "DataFormats/PatCandidates/interface/Electron.h"
 
+using namespace reco;
 
 class EGammaMvaEleEstimatorCSA14{
   public:

--- a/EgammaAnalysis/ElectronTools/interface/ElectronEffectiveArea.h
+++ b/EgammaAnalysis/ElectronTools/interface/ElectronEffectiveArea.h
@@ -20,8 +20,6 @@
 #ifndef STANDALONE
 #endif
 
-using namespace std;
-
 class ElectronEffectiveArea{
  public:
   ElectronEffectiveArea();

--- a/EgammaAnalysis/ElectronTools/interface/ElectronEffectiveArea.h
+++ b/EgammaAnalysis/ElectronTools/interface/ElectronEffectiveArea.h
@@ -20,6 +20,7 @@
 #ifndef STANDALONE
 #endif
 
+using namespace std;
 
 class ElectronEffectiveArea{
  public:
@@ -64,7 +65,6 @@ class ElectronEffectiveArea{
     static Double_t GetElectronEffectiveArea(ElectronEffectiveAreaType type, Double_t SCEta, 
                                              ElectronEffectiveAreaTarget EffectiveAreaTarget = kEleEAData2011) {
       
-      using namespace std;
       Double_t EffectiveArea = 0;
 
 

--- a/EgammaAnalysis/ElectronTools/interface/ElectronEnergyCalibrator.h
+++ b/EgammaAnalysis/ElectronTools/interface/ElectronEnergyCalibrator.h
@@ -8,12 +8,6 @@
 #include <sstream>
 #include <iostream>
 
-using std::string;
-using std::vector;
-using std::ifstream;
-using std::istringstream;
-using std::cout;
-
 namespace edm {
   class StreamID;
 }
@@ -46,61 +40,60 @@ struct linearityCorrectionValues
 
 class ElectronEnergyCalibrator
 {
-    public:
-        ElectronEnergyCalibrator( const std::string pathData, 
-                                  const std::string pathLinData,
-                                  const std::string dataset, 
-                                  int correctionsType, 
-                                  bool applyLinearityCorrection, 
-                                  double lumiRatio, 
-                                  bool isMC, 
-                                  bool updateEnergyErrors, 
-                                  bool verbose, 
-                                  bool synchronization
-                                ) : 
-                                  pathData_(pathData), 
-                                  pathLinData_(pathLinData), 
-                                  dataset_(dataset), 
-                                  correctionsType_(correctionsType), 
-                                  applyLinearityCorrection_(applyLinearityCorrection),
-                                  lumiRatio_(lumiRatio), 
-                                  isMC_(isMC), 
-                                  updateEnergyErrors_(updateEnergyErrors), 
-                                  verbose_(verbose), 
-                                  synchronization_(synchronization) 
-	    {
-		    init();
-    	}
+ public:
+ ElectronEnergyCalibrator(const std::string pathData, 
+			  const std::string pathLinData,
+			  const std::string dataset, 
+			  int correctionsType, 
+			  bool applyLinearityCorrection, 
+			  double lumiRatio, 
+			  bool isMC, 
+			  bool updateEnergyErrors, 
+			  bool verbose, 
+			  bool synchronization
+			  ) : 
+    pathData_(pathData), 
+    pathLinData_(pathLinData), 
+    dataset_(dataset), 
+    correctionsType_(correctionsType), 
+    applyLinearityCorrection_(applyLinearityCorrection),
+    lumiRatio_(lumiRatio), 
+    isMC_(isMC), 
+    updateEnergyErrors_(updateEnergyErrors), 
+    verbose_(verbose), 
+    synchronization_(synchronization) {
+      init();
+    }
 
-        void calibrate(SimpleElectron &electron, edm::StreamID const&);
-        void correctLinearity(SimpleElectron &electron);
-
-    private:
-        void init();
-        void splitString( const string &fullstr, 
-                          vector<string> &elements, 
-                          const string &delimiter
-                        );
-        double stringToDouble(const string &str);
+    void calibrate(SimpleElectron &electron, edm::StreamID const&);
+    void correctLinearity(SimpleElectron &electron);
+				  
+ private:
+    void init();
+    void splitString( const std::string &fullstr, 
+		      std::vector<std::string> &elements, 
+		      const std::string &delimiter
+		      );
+    double stringToDouble(const std::string &str);
       
-        double newEnergy_ ;
-        double newEnergyError_ ;
-        
-        std::string pathData_;
-        std::string pathLinData_;
-        std::string dataset_;
-        int correctionsType_;
-        bool applyLinearityCorrection_;
-        double lumiRatio_;
-        bool isMC_;
-        bool updateEnergyErrors_;
-        bool verbose_;
-        bool synchronization_;
-      
-        correctionValues corrValArray[100];
-        correctionValues corrValMC;
-        linearityCorrectionValues linCorrValArray[100];
-        int nCorrValRaw, nLinCorrValRaw;
+    double newEnergy_ ;
+    double newEnergyError_ ;
+    
+    std::string pathData_;
+    std::string pathLinData_;
+    std::string dataset_;
+    int correctionsType_;
+    bool applyLinearityCorrection_;
+    double lumiRatio_;
+    bool isMC_;
+    bool updateEnergyErrors_;
+    bool verbose_;
+    bool synchronization_;
+    
+    correctionValues corrValArray[100];
+    correctionValues corrValMC;
+    linearityCorrectionValues linCorrValArray[100];
+    int nCorrValRaw, nLinCorrValRaw;
 };
 
 #endif

--- a/EgammaAnalysis/ElectronTools/interface/ElectronEnergyCalibrator.h
+++ b/EgammaAnalysis/ElectronTools/interface/ElectronEnergyCalibrator.h
@@ -8,6 +8,11 @@
 #include <sstream>
 #include <iostream>
 
+using std::string;
+using std::vector;
+using std::ifstream;
+using std::istringstream;
+using std::cout;
 
 namespace edm {
   class StreamID;
@@ -72,11 +77,11 @@ class ElectronEnergyCalibrator
 
     private:
         void init();
-        void splitString( const std::string &fullstr, 
-                          std::vector<std::string> &elements, 
-                          const std::string &delimiter
+        void splitString( const string &fullstr, 
+                          vector<string> &elements, 
+                          const string &delimiter
                         );
-        double stringToDouble(const std::string &str);
+        double stringToDouble(const string &str);
       
         double newEnergy_ ;
         double newEnergyError_ ;

--- a/EgammaAnalysis/ElectronTools/interface/ElectronEnergyCalibratorRun2.h
+++ b/EgammaAnalysis/ElectronTools/interface/ElectronEnergyCalibratorRun2.h
@@ -1,0 +1,46 @@
+#ifndef ElectronEnergyCalibratorRun2_h
+#define ElectronEnergyCalibratorRun2_h
+
+#include <TRandom.h>
+#include "EgammaAnalysis/ElectronTools/interface/SimpleElectron.h"
+#include "EgammaAnalysis/ElectronTools/interface/EpCombinationTool.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include <vector>
+
+class ElectronEnergyCalibratorRun2 {
+    public:
+        // dummy constructor for persistence
+        ElectronEnergyCalibratorRun2() {}
+
+        // further configuration will be added when we will learn how it will work
+        ElectronEnergyCalibratorRun2(EpCombinationTool &combinator, bool isMC, bool synchronization, std::vector<double> smearings, std::vector<double> scales) ;
+        ~ElectronEnergyCalibratorRun2() ;
+    
+        /// Initialize with a random number generator (if not done, it will use the CMSSW service)
+        /// Caller code owns the TRandom.
+        void initPrivateRng(TRandom *rnd) ;
+
+        /// Correct this electron. 
+        /// StreamID is needed when used with CMSSW Random Number Generator
+        void calibrate(SimpleElectron &electron, edm::StreamID const & id = edm::StreamID::invalidStreamID()) const ;
+
+        /// Correct this electron. 
+        /// StreamID is needed when used with CMSSW Random Number Generator
+        void calibrate(reco::GsfElectron &electron, unsigned int runNumber, edm::StreamID const & id = edm::StreamID::invalidStreamID()) const ;
+
+    protected:    
+        // whatever data will be needed
+        EpCombinationTool *epCombinationTool_;
+        bool isMC_, synchronization_;
+        TRandom *rng_;
+	std::vector<double> smearings_;
+	std::vector<double> scales_;
+
+        /// Return a number distributed as a unit gaussian, drawn from the private RNG if initPrivateRng was called, 
+        /// or from the CMSSW RandomNumberGenerator service
+        /// If synchronization is set to true, it returns a fixed number (1.0)
+        double gauss(edm::StreamID const& id) const ;
+};
+
+#endif

--- a/EgammaAnalysis/ElectronTools/interface/EpCombinationTool.h
+++ b/EgammaAnalysis/ElectronTools/interface/EpCombinationTool.h
@@ -12,17 +12,18 @@ class EpCombinationTool
     public:
         EpCombinationTool();
         ~EpCombinationTool();
+        // forbid copy and assignment, since we have a custom deleter
+        EpCombinationTool(const EpCombinationTool &other) = delete;
+        EpCombinationTool & operator=(const EpCombinationTool &other) = delete;
 
-        bool init(const std::string& regressionFile, const std::string& bdtName="");
-//        float combine(float energy, float energyError,
-//                float momentum, float momentumError, 
-//                int electronClass,
-//                bool isEcalDriven, bool isTrackerDriven, bool isEB);
-	void combine(SimpleElectron & mySimpleElectron);
+        bool init(const GBRForest *forest) ;
+        bool init(const std::string& regressionFile, const std::string& bdtName);
+	void combine(SimpleElectron & mySimpleElectron) const;
 
 
     private:
-        GBRForest* m_forest;
+        const GBRForest* m_forest;
+        bool  m_ownForest;
 
 };
 

--- a/EgammaAnalysis/ElectronTools/interface/PFIsolationEstimator.h
+++ b/EgammaAnalysis/ElectronTools/interface/PFIsolationEstimator.h
@@ -50,11 +50,6 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
-using namespace std;
-using namespace edm;
-using namespace reco;
-
-
 class PFIsolationEstimator{
  public:
   PFIsolationEstimator();
@@ -65,7 +60,7 @@ class PFIsolationEstimator{
     kPhoton  =  1            // MVA for triggering electrons
   };
   
-
+  
   void     initializeElectronIsolation( Bool_t  bApplyVeto);
   void     initializePhotonIsolation( Bool_t  bApplyVeto);
   void     initializeElectronIsolationInRings( Bool_t  bApplyVeto, int iNumberOfRings, float fRingSize );
@@ -73,18 +68,18 @@ class PFIsolationEstimator{
   void     initializeRings(int iNumberOfRings, float fRingSize);
   Bool_t   isInitialized() const { return fisInitialized; }
   
-
+  
   float fGetIsolation(const reco::PFCandidate * pfCandidate,const reco::PFCandidateCollection* pfParticlesColl,reco::VertexRef vtx, edm::Handle< reco::VertexCollection >  vertices );
-  vector<float >  fGetIsolationInRings(const reco::PFCandidate * pfCandidate,const reco::PFCandidateCollection* pfParticlesColl,reco::VertexRef vtx, edm::Handle< reco::VertexCollection > vertices);
+  std::vector<float >  fGetIsolationInRings(const reco::PFCandidate * pfCandidate,const reco::PFCandidateCollection* pfParticlesColl,reco::VertexRef vtx, edm::Handle< reco::VertexCollection > vertices);
   
    float fGetIsolation(const reco::Photon* photon,const reco::PFCandidateCollection* pfParticlesColl,reco::VertexRef vtx, edm::Handle< reco::VertexCollection >  vertices );
-  vector<float >  fGetIsolationInRings(const reco::Photon* photon,const reco::PFCandidateCollection* pfParticlesColl,reco::VertexRef vtx, edm::Handle< reco::VertexCollection > vertices);
+   std::vector<float >  fGetIsolationInRings(const reco::Photon* photon,const reco::PFCandidateCollection* pfParticlesColl,reco::VertexRef vtx, edm::Handle< reco::VertexCollection > vertices);
 
    float fGetIsolation(const reco::GsfElectron* electron,const reco::PFCandidateCollection* pfParticlesColl,const reco::VertexRef vtx, edm::Handle< reco::VertexCollection >  vertices );
-  vector<float >  fGetIsolationInRings(const reco::GsfElectron* electron,const reco::PFCandidateCollection* pfParticlesColl,reco::VertexRef vtx, edm::Handle< reco::VertexCollection > vertices);
+   std::vector<float >  fGetIsolationInRings(const reco::GsfElectron* electron,const reco::PFCandidateCollection* pfParticlesColl,reco::VertexRef vtx, edm::Handle< reco::VertexCollection > vertices);
 
 
-  VertexRef chargedHadronVertex(edm::Handle< reco::VertexCollection > verticies, const reco::PFCandidate& pfcand );
+   reco::VertexRef chargedHadronVertex(edm::Handle< reco::VertexCollection > verticies, const reco::PFCandidate& pfcand );
 
   void setConeSize(float fValue = 0.4){ fConeSize = fValue;};
 
@@ -138,10 +133,10 @@ class PFIsolationEstimator{
   float getIsolationCharged(){  fIsolationCharged =   fIsolationInRingsCharged[0]; return fIsolationCharged; };
   float getIsolationChargedAll(){ return fIsolationChargedAll; };
 
-  vector<float >  getIsolationInRingsPhoton(){ return fIsolationInRingsPhoton; };
-  vector<float >  getIsolationInRingsNeutral(){ return fIsolationInRingsNeutral; };
-  vector<float >  getIsolationInRingsCharged(){ return fIsolationInRingsCharged; };
-  vector<float >  getIsolationInRingsChargedAll(){ return fIsolationInRingsChargedAll; };
+  std::vector<float >  getIsolationInRingsPhoton(){ return fIsolationInRingsPhoton; };
+  std::vector<float >  getIsolationInRingsNeutral(){ return fIsolationInRingsNeutral; };
+  std::vector<float >  getIsolationInRingsCharged(){ return fIsolationInRingsCharged; };
+  std::vector<float >  getIsolationInRingsChargedAll(){ return fIsolationInRingsChargedAll; };
 
 
   void setNumbersOfRings(int iValue = 1){iNumberOfRings = iValue;};
@@ -165,11 +160,11 @@ class PFIsolationEstimator{
   float                   fIsolationCharged;
   float                   fIsolationChargedAll;
   
-  vector<float >          fIsolationInRings;
-  vector<float >          fIsolationInRingsPhoton;
-  vector<float >          fIsolationInRingsNeutral;
-  vector<float >          fIsolationInRingsCharged;  
-  vector<float >          fIsolationInRingsChargedAll;
+  std::vector<float >     fIsolationInRings;
+  std::vector<float >     fIsolationInRingsPhoton;
+  std::vector<float >     fIsolationInRingsNeutral;
+  std::vector<float >     fIsolationInRingsCharged;  
+  std::vector<float >     fIsolationInRingsChargedAll;
 
   Bool_t                    checkClosestZVertex;
   float                     fConeSize;
@@ -230,7 +225,7 @@ class PFIsolationEstimator{
   float                   fVy;
   float                   fVz;
   
-  SuperClusterRef         refSC;
+  reco::SuperClusterRef         refSC;
   bool                    pivotInBarrel;
 
   math::XYZVector         vtxWRTCandidate;

--- a/EgammaAnalysis/ElectronTools/interface/PFIsolationEstimator.h
+++ b/EgammaAnalysis/ElectronTools/interface/PFIsolationEstimator.h
@@ -50,6 +50,10 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
+using namespace std;
+using namespace edm;
+using namespace reco;
+
 
 class PFIsolationEstimator{
  public:
@@ -71,16 +75,16 @@ class PFIsolationEstimator{
   
 
   float fGetIsolation(const reco::PFCandidate * pfCandidate,const reco::PFCandidateCollection* pfParticlesColl,reco::VertexRef vtx, edm::Handle< reco::VertexCollection >  vertices );
-  std::vector<float >  fGetIsolationInRings(const reco::PFCandidate * pfCandidate,const reco::PFCandidateCollection* pfParticlesColl,reco::VertexRef vtx, edm::Handle< reco::VertexCollection > vertices);
+  vector<float >  fGetIsolationInRings(const reco::PFCandidate * pfCandidate,const reco::PFCandidateCollection* pfParticlesColl,reco::VertexRef vtx, edm::Handle< reco::VertexCollection > vertices);
   
    float fGetIsolation(const reco::Photon* photon,const reco::PFCandidateCollection* pfParticlesColl,reco::VertexRef vtx, edm::Handle< reco::VertexCollection >  vertices );
-  std::vector<float >  fGetIsolationInRings(const reco::Photon* photon,const reco::PFCandidateCollection* pfParticlesColl,reco::VertexRef vtx, edm::Handle< reco::VertexCollection > vertices);
+  vector<float >  fGetIsolationInRings(const reco::Photon* photon,const reco::PFCandidateCollection* pfParticlesColl,reco::VertexRef vtx, edm::Handle< reco::VertexCollection > vertices);
 
    float fGetIsolation(const reco::GsfElectron* electron,const reco::PFCandidateCollection* pfParticlesColl,const reco::VertexRef vtx, edm::Handle< reco::VertexCollection >  vertices );
-  std::vector<float >  fGetIsolationInRings(const reco::GsfElectron* electron,const reco::PFCandidateCollection* pfParticlesColl,reco::VertexRef vtx, edm::Handle< reco::VertexCollection > vertices);
+  vector<float >  fGetIsolationInRings(const reco::GsfElectron* electron,const reco::PFCandidateCollection* pfParticlesColl,reco::VertexRef vtx, edm::Handle< reco::VertexCollection > vertices);
 
 
-  reco::VertexRef chargedHadronVertex(edm::Handle< reco::VertexCollection > verticies, const reco::PFCandidate& pfcand );
+  VertexRef chargedHadronVertex(edm::Handle< reco::VertexCollection > verticies, const reco::PFCandidate& pfcand );
 
   void setConeSize(float fValue = 0.4){ fConeSize = fValue;};
 
@@ -134,10 +138,10 @@ class PFIsolationEstimator{
   float getIsolationCharged(){  fIsolationCharged =   fIsolationInRingsCharged[0]; return fIsolationCharged; };
   float getIsolationChargedAll(){ return fIsolationChargedAll; };
 
-  std::vector<float >  getIsolationInRingsPhoton(){ return fIsolationInRingsPhoton; };
-  std::vector<float >  getIsolationInRingsNeutral(){ return fIsolationInRingsNeutral; };
-  std::vector<float >  getIsolationInRingsCharged(){ return fIsolationInRingsCharged; };
-  std::vector<float >  getIsolationInRingsChargedAll(){ return fIsolationInRingsChargedAll; };
+  vector<float >  getIsolationInRingsPhoton(){ return fIsolationInRingsPhoton; };
+  vector<float >  getIsolationInRingsNeutral(){ return fIsolationInRingsNeutral; };
+  vector<float >  getIsolationInRingsCharged(){ return fIsolationInRingsCharged; };
+  vector<float >  getIsolationInRingsChargedAll(){ return fIsolationInRingsChargedAll; };
 
 
   void setNumbersOfRings(int iValue = 1){iNumberOfRings = iValue;};
@@ -161,11 +165,11 @@ class PFIsolationEstimator{
   float                   fIsolationCharged;
   float                   fIsolationChargedAll;
   
-  std::vector<float >          fIsolationInRings;
-  std::vector<float >          fIsolationInRingsPhoton;
-  std::vector<float >          fIsolationInRingsNeutral;
-  std::vector<float >          fIsolationInRingsCharged;  
-  std::vector<float >          fIsolationInRingsChargedAll;
+  vector<float >          fIsolationInRings;
+  vector<float >          fIsolationInRingsPhoton;
+  vector<float >          fIsolationInRingsNeutral;
+  vector<float >          fIsolationInRingsCharged;  
+  vector<float >          fIsolationInRingsChargedAll;
 
   Bool_t                    checkClosestZVertex;
   float                     fConeSize;
@@ -226,7 +230,7 @@ class PFIsolationEstimator{
   float                   fVy;
   float                   fVz;
   
-  reco::SuperClusterRef   refSC;
+  SuperClusterRef         refSC;
   bool                    pivotInBarrel;
 
   math::XYZVector         vtxWRTCandidate;

--- a/EgammaAnalysis/ElectronTools/interface/PhotonEnergyCalibratorRun2.h
+++ b/EgammaAnalysis/ElectronTools/interface/PhotonEnergyCalibratorRun2.h
@@ -1,0 +1,44 @@
+#ifndef PhotonEnergyCalibratorRun2_h
+#define PhotonEnergyCalibratorRun2_h
+
+#include <TRandom.h>
+#include "EgammaAnalysis/ElectronTools/interface/SimplePhoton.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include <vector>
+
+class PhotonEnergyCalibratorRun2 {
+ public:
+  // dummy constructor for persistence
+  PhotonEnergyCalibratorRun2() {}
+  
+  // further configuration will be added when we will learn how it will work
+  PhotonEnergyCalibratorRun2(bool isMC, bool synchronization, std::vector<double> smearings, std::vector<double> scales);
+  ~PhotonEnergyCalibratorRun2() ;
+  
+  /// Initialize with a random number generator (if not done, it will use the CMSSW service)
+  /// Caller code owns the TRandom.
+  void initPrivateRng(TRandom *rnd) ;
+  
+  /// Correct this electron. 
+  /// StreamID is needed when used with CMSSW Random Number Generator
+  void calibrate(SimplePhoton &photon, edm::StreamID const & id = edm::StreamID::invalidStreamID()) const ;
+  
+  /// Correct this electron. 
+  /// StreamID is needed when used with CMSSW Random Number Generator
+  void calibrate(reco::Photon &photon, unsigned int runNumber, edm::StreamID const & id = edm::StreamID::invalidStreamID()) const ;
+  
+ protected:    
+  // whatever data will be needed
+  bool isMC_, synchronization_;
+  TRandom *rng_;
+  std::vector<double> smearings_;
+  std::vector<double> scales_;
+  
+  /// Return a number distributed as a unit gaussian, drawn from the private RNG if initPrivateRng was called, 
+  /// or from the CMSSW RandomNumberGenerator service
+  /// If synchronization is set to true, it returns a fixed number (1.0)
+  double gauss(edm::StreamID const& id) const ;
+};
+
+#endif

--- a/EgammaAnalysis/ElectronTools/interface/SimpleElectron.h
+++ b/EgammaAnalysis/ElectronTools/interface/SimpleElectron.h
@@ -1,5 +1,9 @@
 #ifndef SimpleElectron_H
 #define SimpleElectron_H
+ 
+#ifndef SimpleElectron_STANDALONE
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"        
+#endif
 
 class SimpleElectron
 {
@@ -36,32 +40,40 @@ class SimpleElectron
                         isMC_(isMC), 
                         isEcalDriven_(isEcalDriven), 
                         isTrackerDriven_(isTrackerDriven), 
+                        newEnergy_(regEnergy_), 
+                        newEnergyError_(regEnergyError_),
                         combinedMomentum_(combinedMomentum), 
-                        combinedMomentumError_(combinedMomentumError) 
+                        combinedMomentumError_(combinedMomentumError),
+                        scale_(1.0), smearing_(0.0)
         {}
 	    ~SimpleElectron(){}	
 
+#ifndef SimpleElectron_STANDALONE
+        explicit SimpleElectron(const reco::GsfElectron &in, unsigned int runNumber, bool isMC) ;
+        void writeTo(reco::GsfElectron & out) const ;
+#endif
+
     	//accessors
-    	double getNewEnergy(){return newEnergy_;}
-    	double getNewEnergyError(){return newEnergyError_;}
-    	double getCombinedMomentum(){return combinedMomentum_;}
-    	double getCombinedMomentumError(){return combinedMomentumError_;}
-    	double getScale(){return scale_;}
-    	double getSmearing(){return smearing_;}
-    	double getSCEnergy(){return scEnergy_;}
-    	double getSCEnergyError(){return scEnergyError_;}
-    	double getRegEnergy(){return regEnergy_;}
-    	double getRegEnergyError(){return regEnergyError_;}
-    	double getTrackerMomentum(){return trackMomentum_;}
-    	double getTrackerMomentumError(){return trackMomentumError_;}
-    	double getEta(){return eta_;}
-    	float getR9(){return r9_;}
-    	int getElClass(){return eClass_;}
-    	int getRunNumber(){return run_;}
-    	bool isEB(){return isEB_;}
-    	bool isMC(){return isMC_;}
-    	bool isEcalDriven(){return isEcalDriven_;}
-    	bool isTrackerDriven(){return isTrackerDriven_;}
+    	double getNewEnergy() const {return newEnergy_;}
+    	double getNewEnergyError() const {return newEnergyError_;}
+    	double getCombinedMomentum() const {return combinedMomentum_;}
+    	double getCombinedMomentumError() const {return combinedMomentumError_;}
+    	double getScale() const {return scale_;}
+    	double getSmearing() const {return smearing_;}
+    	double getSCEnergy() const {return scEnergy_;}
+    	double getSCEnergyError() const {return scEnergyError_;}
+    	double getRegEnergy() const {return regEnergy_;}
+    	double getRegEnergyError() const {return regEnergyError_;}
+    	double getTrackerMomentum() const {return trackMomentum_;}
+    	double getTrackerMomentumError() const {return trackMomentumError_;}
+    	double getEta() const {return eta_;}
+    	float getR9() const {return r9_;}
+    	int getElClass() const {return eClass_;}
+    	int getRunNumber() const {return run_;}
+    	bool isEB() const {return isEB_;}
+    	bool isMC() const {return isMC_;}
+    	bool isEcalDriven() const {return isEcalDriven_;}
+    	bool isTrackerDriven() const {return isTrackerDriven_;}
     
     	//setters
     	void setCombinedMomentum(double combinedMomentum){combinedMomentum_ = combinedMomentum;}

--- a/EgammaAnalysis/ElectronTools/interface/SimplePhoton.h
+++ b/EgammaAnalysis/ElectronTools/interface/SimplePhoton.h
@@ -1,0 +1,80 @@
+#ifndef SimplePhoton_H
+#define SimplePhoton_H
+ 
+#ifndef SimpleElectron_STANDALONE
+#include "DataFormats/EgammaCandidates/interface/Photon.h"        
+#endif
+
+class SimplePhoton {
+ public:
+  SimplePhoton() {}
+ SimplePhoton(double run, 
+	      double eClass,
+	      double r9, 
+	      double scEnergy, 
+	      double scEnergyError, 
+	      double regEnergy, 
+	      double regEnergyError, 
+	      double eta, 
+	      bool isEB, 
+	      bool isMC
+	      ) : 
+  run_(run),
+    eClass_(eClass),
+    r9_(r9),
+    scEnergy_(scEnergy), 
+    scEnergyError_(scEnergyError), 
+    regEnergy_(regEnergy), 
+    regEnergyError_(regEnergyError), 
+    eta_(eta), 
+    isEB_(isEB), 
+    isMC_(isMC), 
+    newEnergy_(regEnergy_), 
+    newEnergyError_(regEnergyError_),
+    scale_(1.0), smearing_(0.0)
+    {}
+  ~SimplePhoton() {}	
+
+#ifndef SimplePhoton_STANDALONE
+  explicit SimplePhoton(const reco::Photon &in, unsigned int runNumber, bool isMC) ;
+  void writeTo(reco::Photon& out) const ;
+#endif
+
+  //accessors
+  double getNewEnergy() const {return newEnergy_;}
+  double getNewEnergyError() const {return newEnergyError_;}
+  double getScale() const {return scale_;}
+  double getSmearing() const {return smearing_;}
+  double getSCEnergy() const {return scEnergy_;}
+  double getSCEnergyError() const {return scEnergyError_;}
+  double getRegEnergy() const {return regEnergy_;}
+  double getRegEnergyError() const {return regEnergyError_;}
+  double getEta() const {return eta_;}
+  float getR9() const {return r9_;}
+  int getElClass() const {return eClass_;}
+  int getRunNumber() const {return run_;}
+  bool isEB() const {return isEB_;}
+  bool isMC() const {return isMC_;}
+	    
+  //setters
+  void setNewEnergy(double newEnergy){newEnergy_ = newEnergy;}
+  void setNewEnergyError(double newEnergyError){newEnergyError_ = newEnergyError;}
+	    
+ private:
+  double run_; 
+  double eClass_;
+  double r9_;
+  double scEnergy_; 
+  double scEnergyError_; 
+  double regEnergy_; 
+  double regEnergyError_;
+  double eta_;
+  bool isEB_;
+  bool isMC_;
+  double newEnergy_; 
+  double newEnergyError_; 
+  double scale_; 
+  double smearing_;
+};
+
+#endif

--- a/EgammaAnalysis/ElectronTools/plugins/CalibratedElectronProducer.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/CalibratedElectronProducer.cc
@@ -31,127 +31,123 @@
 
 #include <iostream>
 
-using namespace edm ;
-using namespace std ;
-using namespace reco ;
-
 CalibratedElectronProducer::CalibratedElectronProducer( const edm::ParameterSet & cfg )
 {
-    inputElectronsToken_ = consumes<reco::GsfElectronCollection>(cfg.getParameter<edm::InputTag>("inputElectronsTag"));
+  inputElectronsToken_ = consumes<reco::GsfElectronCollection>(cfg.getParameter<edm::InputTag>("inputElectronsTag"));
+  
+  energyRegToken_      = consumes<edm::ValueMap<double> >(cfg.getParameter<edm::InputTag>("nameEnergyReg"));
+  energyErrorRegToken_ = consumes<edm::ValueMap<double> >(cfg.getParameter<edm::InputTag>("nameEnergyErrorReg"));
+  
+  recHitCollectionEBToken_ = consumes<EcalRecHitCollection>(cfg.getParameter<edm::InputTag>("recHitCollectionEB"));
+  recHitCollectionEEToken_ = consumes<EcalRecHitCollection>(cfg.getParameter<edm::InputTag>("recHitCollectionEE"));
 
-    energyRegToken_      = consumes<edm::ValueMap<double> >(cfg.getParameter<edm::InputTag>("nameEnergyReg"));
-    energyErrorRegToken_ = consumes<edm::ValueMap<double> >(cfg.getParameter<edm::InputTag>("nameEnergyErrorReg"));
-
-    recHitCollectionEBToken_ = consumes<EcalRecHitCollection>(cfg.getParameter<edm::InputTag>("recHitCollectionEB"));
-    recHitCollectionEEToken_ = consumes<EcalRecHitCollection>(cfg.getParameter<edm::InputTag>("recHitCollectionEE"));
-
-
-    nameNewEnergyReg_      = cfg.getParameter<std::string>("nameNewEnergyReg");
-    nameNewEnergyErrorReg_ = cfg.getParameter<std::string>("nameNewEnergyErrorReg");
-    newElectronName_ = cfg.getParameter<std::string>("outputGsfElectronCollectionLabel");
+  
+  nameNewEnergyReg_      = cfg.getParameter<std::string>("nameNewEnergyReg");
+  nameNewEnergyErrorReg_ = cfg.getParameter<std::string>("nameNewEnergyErrorReg");
+  newElectronName_ = cfg.getParameter<std::string>("outputGsfElectronCollectionLabel");
 
 
-    dataset = cfg.getParameter<std::string>("inputDataset");
-    isMC = cfg.getParameter<bool>("isMC");
-    updateEnergyError = cfg.getParameter<bool>("updateEnergyError");
-    lumiRatio = cfg.getParameter<double>("lumiRatio");
-    correctionsType = cfg.getParameter<int>("correctionsType");
-    applyLinearityCorrection = cfg.getParameter<bool>("applyLinearityCorrection");
-    combinationType = cfg.getParameter<int>("combinationType");
-    verbose = cfg.getParameter<bool>("verbose");
-    synchronization = cfg.getParameter<bool>("synchronization");
-    combinationRegressionInputPath = cfg.getParameter<std::string>("combinationRegressionInputPath");
-    scaleCorrectionsInputPath = cfg.getParameter<std::string>("scaleCorrectionsInputPath");
-    linCorrectionsInputPath   = cfg.getParameter<std::string>("linearityCorrectionsInputPath");
-
-    //basic checks
-    if ( isMC && ( dataset != "Summer11" && dataset != "Fall11"
-        && dataset!= "Summer12" && dataset != "Summer12_DR53X_HCP2012"
-        && dataset != "Summer12_LegacyPaper" ) )
+  dataset = cfg.getParameter<std::string>("inputDataset");
+  isMC = cfg.getParameter<bool>("isMC");
+  updateEnergyError = cfg.getParameter<bool>("updateEnergyError");
+  lumiRatio = cfg.getParameter<double>("lumiRatio");
+  correctionsType = cfg.getParameter<int>("correctionsType");
+  applyLinearityCorrection = cfg.getParameter<bool>("applyLinearityCorrection");
+  combinationType = cfg.getParameter<int>("combinationType");
+  verbose = cfg.getParameter<bool>("verbose");
+  synchronization = cfg.getParameter<bool>("synchronization");
+  combinationRegressionInputPath = cfg.getParameter<std::string>("combinationRegressionInputPath");
+  scaleCorrectionsInputPath = cfg.getParameter<std::string>("scaleCorrectionsInputPath");
+  linCorrectionsInputPath   = cfg.getParameter<std::string>("linearityCorrectionsInputPath");
+  
+  //basic checks
+  if ( isMC && ( dataset != "Summer11" && dataset != "Fall11"
+		 && dataset!= "Summer12" && dataset != "Summer12_DR53X_HCP2012"
+		 && dataset != "Summer12_LegacyPaper" ) )
     {
-        throw cms::Exception("CalibratedgsfElectronProducer|ConfigError") << "Unknown MC dataset";
+      throw cms::Exception("CalibratedgsfElectronProducer|ConfigError") << "Unknown MC dataset";
     }
     if ( !isMC && ( dataset != "Prompt" && dataset != "ReReco"
-        && dataset != "Jan16ReReco" && dataset != "ICHEP2012"
-        && dataset != "Moriond2013" && dataset != "22Jan2013ReReco" ) )
-    {
+		    && dataset != "Jan16ReReco" && dataset != "ICHEP2012"
+		    && dataset != "Moriond2013" && dataset != "22Jan2013ReReco" ) )
+      {
         throw cms::Exception("CalibratedgsfElectronProducer|ConfigError") << "Unknown Data dataset";
     }
-
+    
     // Linearity correction only applied on combined momentum obtain with regression combination
     if(combinationType!=3 && applyLinearityCorrection)
-    {
+      {
         std::cout << "[CalibratedElectronProducer] "
-            << "Warning: you chose combinationType!=3 and applyLinearityCorrection=True. Linearity corrections are only applied on top of combination 3." << std::endl;
-    }
-
+		  << "Warning: you chose combinationType!=3 and applyLinearityCorrection=True. Linearity corrections are only applied on top of combination 3." << std::endl;
+      }
+    
     std::cout << "[CalibratedGsfElectronProducer] Correcting scale for dataset " << dataset << std::endl;
-
+    
     //initializations
     std::string pathToDataCorr;
     switch (correctionsType)
-    {
-        case 0:
-      	    break;
-    	case 1:
-    		if ( verbose )
-            {
-                std::cout << "You choose regression 1 scale corrections" << std::endl;
-            }
-    	    break;
-    	case 2:
-    		if ( verbose )
-            {
-                std::cout << "You choose regression 2 scale corrections." << std::endl;
-            }
-    	    break;
-    	case 3:
-            throw cms::Exception("CalibratedgsfElectronProducer|ConfigError")
-                << "You choose standard non-regression ecal energy scale corrections. They are not implemented yet.";
-    		break;
-    	default:
-            throw cms::Exception("CalibratedgsfElectronProducer|ConfigError")
-                << "Unknown correctionsType !!!" ;
-    }
-
+      {
+      case 0:
+	break;
+      case 1:
+	if ( verbose )
+	  {
+	    std::cout << "You choose regression 1 scale corrections" << std::endl;
+	  }
+	break;
+      case 2:
+	if ( verbose )
+	  {
+	    std::cout << "You choose regression 2 scale corrections." << std::endl;
+	  }
+	break;
+      case 3:
+	throw cms::Exception("CalibratedgsfElectronProducer|ConfigError")
+	  << "You choose standard non-regression ecal energy scale corrections. They are not implemented yet.";
+	break;
+      default:
+	throw cms::Exception("CalibratedgsfElectronProducer|ConfigError")
+	  << "Unknown correctionsType !!!" ;
+      }
+    
     theEnCorrector = new ElectronEnergyCalibrator
-        (
-            edm::FileInPath(scaleCorrectionsInputPath.c_str()).fullPath().c_str(),
-            edm::FileInPath(linCorrectionsInputPath.c_str()).fullPath().c_str(),
-            dataset,
-            correctionsType,
-            applyLinearityCorrection,
-            lumiRatio,
-            isMC,
-            updateEnergyError,
-            verbose,
-            synchronization
-        );
-
+      (
+       edm::FileInPath(scaleCorrectionsInputPath.c_str()).fullPath().c_str(),
+       edm::FileInPath(linCorrectionsInputPath.c_str()).fullPath().c_str(),
+       dataset,
+       correctionsType,
+       applyLinearityCorrection,
+       lumiRatio,
+       isMC,
+       updateEnergyError,
+       verbose,
+       synchronization
+       );
+    
     if ( verbose )
-    {
+      {
         std::cout<<"[CalibratedGsfElectronProducer] "
-        << "ElectronEnergyCalibrator object is created" << std::endl;
-    }
-
+		 << "ElectronEnergyCalibrator object is created" << std::endl;
+      }
+    
     myEpCombinationTool = new EpCombinationTool();
     myEpCombinationTool->init
-        (
-            edm::FileInPath(combinationRegressionInputPath.c_str()).fullPath().c_str(),
-            "CombinationWeight"
-        );
-
+      (
+       edm::FileInPath(combinationRegressionInputPath.c_str()).fullPath().c_str(),
+       "CombinationWeight"
+       );
+    
     myCombinator = new ElectronEPcombinator();
-
+    
     if ( verbose )
-    {
+      {
         std::cout << "[CalibratedGsfElectronProducer] "
-        << "Combination tools are created and initialized" << std::endl;
-    }
-
+		  << "Combination tools are created and initialized" << std::endl;
+      }
+    
     produces<edm::ValueMap<double> >(nameNewEnergyReg_);
     produces<edm::ValueMap<double> >(nameNewEnergyErrorReg_);
-    produces<GsfElectronCollection> (newElectronName_);
+    produces<reco::GsfElectronCollection> (newElectronName_);
     geomInitialized_ = false;
 }
 
@@ -160,220 +156,220 @@ CalibratedElectronProducer::~CalibratedElectronProducer()
 
 void CalibratedElectronProducer::produce( edm::Event & event, const edm::EventSetup & setup )
 {
-    if (!geomInitialized_)
+  if (!geomInitialized_)
     {
-        edm::ESHandle<CaloTopology> theCaloTopology;
-        setup.get<CaloTopologyRecord>().get(theCaloTopology);
-        ecalTopology_ = & (*theCaloTopology);
-
-        edm::ESHandle<CaloGeometry> theCaloGeometry;
-        setup.get<CaloGeometryRecord>().get(theCaloGeometry);
-        caloGeometry_ = & (*theCaloGeometry);
-        geomInitialized_ = true;
+      edm::ESHandle<CaloTopology> theCaloTopology;
+      setup.get<CaloTopologyRecord>().get(theCaloTopology);
+      ecalTopology_ = & (*theCaloTopology);
+      
+      edm::ESHandle<CaloGeometry> theCaloGeometry;
+      setup.get<CaloGeometryRecord>().get(theCaloGeometry);
+      caloGeometry_ = & (*theCaloGeometry);
+      geomInitialized_ = true;
     }
+  
+  // Read GsfElectrons
+  edm::Handle<reco::GsfElectronCollection>  oldElectronsH ;
+  event.getByToken(inputElectronsToken_,oldElectronsH) ;
+  
+  // Read RecHits
+  edm::Handle< EcalRecHitCollection > pEBRecHits;
+  edm::Handle< EcalRecHitCollection > pEERecHits;
+  event.getByToken( recHitCollectionEBToken_, pEBRecHits );
+  event.getByToken( recHitCollectionEEToken_, pEERecHits );
 
-    // Read GsfElectrons
-    edm::Handle<reco::GsfElectronCollection>  oldElectronsH ;
-    event.getByToken(inputElectronsToken_,oldElectronsH) ;
-
-    // Read RecHits
-    edm::Handle< EcalRecHitCollection > pEBRecHits;
-    edm::Handle< EcalRecHitCollection > pEERecHits;
-    event.getByToken( recHitCollectionEBToken_, pEBRecHits );
-    event.getByToken( recHitCollectionEEToken_, pEERecHits );
-
-    // ReadValueMaps
-    edm::Handle<edm::ValueMap<double> > valMapEnergyH;
-    event.getByToken(energyRegToken_,valMapEnergyH);
-    edm::Handle<edm::ValueMap<double> > valMapEnergyErrorH;
-    event.getByToken(energyErrorRegToken_,valMapEnergyErrorH);
-
-    // Prepare output collections
-    std::auto_ptr<GsfElectronCollection> electrons( new reco::GsfElectronCollection ) ;
-    // Fillers for ValueMaps:
-    std::auto_ptr<edm::ValueMap<double> > regrNewEnergyMap(new edm::ValueMap<double>() );
-    edm::ValueMap<double>::Filler energyFiller(*regrNewEnergyMap);
-
-    std::auto_ptr<edm::ValueMap<double> > regrNewEnergyErrorMap(new edm::ValueMap<double>() );
-    edm::ValueMap<double>::Filler energyErrorFiller(*regrNewEnergyErrorMap);
-
-    // first clone the initial collection
-    unsigned nElectrons = oldElectronsH->size();
-    for( unsigned iele = 0; iele < nElectrons; ++iele )
+  // ReadValueMaps
+  edm::Handle<edm::ValueMap<double> > valMapEnergyH;
+  event.getByToken(energyRegToken_,valMapEnergyH);
+  edm::Handle<edm::ValueMap<double> > valMapEnergyErrorH;
+  event.getByToken(energyErrorRegToken_,valMapEnergyErrorH);
+  
+  // Prepare output collections
+  std::auto_ptr<reco::GsfElectronCollection> electrons( new reco::GsfElectronCollection ) ;
+  // Fillers for ValueMaps:
+  std::auto_ptr<edm::ValueMap<double> > regrNewEnergyMap(new edm::ValueMap<double>() );
+  edm::ValueMap<double>::Filler energyFiller(*regrNewEnergyMap);
+  
+  std::auto_ptr<edm::ValueMap<double> > regrNewEnergyErrorMap(new edm::ValueMap<double>() );
+  edm::ValueMap<double>::Filler energyErrorFiller(*regrNewEnergyErrorMap);
+  
+  // first clone the initial collection
+  unsigned nElectrons = oldElectronsH->size();
+  for( unsigned iele = 0; iele < nElectrons; ++iele )
     {
       electrons->push_back((*oldElectronsH)[iele]);
     }
-
-    std::vector<double> regressionValues;
-    std::vector<double> regressionErrorValues;
-    regressionValues.reserve(nElectrons);
-    regressionErrorValues.reserve(nElectrons);
-
-    if ( correctionsType != 0 )
+  
+  std::vector<double> regressionValues;
+  std::vector<double> regressionErrorValues;
+  regressionValues.reserve(nElectrons);
+  regressionErrorValues.reserve(nElectrons);
+  
+  if ( correctionsType != 0 )
     {
-        for ( unsigned iele = 0; iele < nElectrons ; ++iele)
+      for ( unsigned iele = 0; iele < nElectrons ; ++iele)
         {
-            reco::GsfElectron & ele  ( (*electrons)[iele]);
-            reco::GsfElectronRef elecRef(oldElectronsH,iele);
-            double regressionEnergy = (*valMapEnergyH)[elecRef];
-            double regressionEnergyError = (*valMapEnergyErrorH)[elecRef];
-
-            regressionValues.push_back(regressionEnergy);
-            regressionErrorValues.push_back(regressionEnergyError);
-
-            //    r9
-            const EcalRecHitCollection * recHits=0;
-            if( ele.isEB() )
+	  reco::GsfElectron & ele  ( (*electrons)[iele]);
+	  reco::GsfElectronRef elecRef(oldElectronsH,iele);
+	  double regressionEnergy = (*valMapEnergyH)[elecRef];
+	  double regressionEnergyError = (*valMapEnergyErrorH)[elecRef];
+	  
+	  regressionValues.push_back(regressionEnergy);
+	  regressionErrorValues.push_back(regressionEnergyError);
+	  
+	  //    r9
+	  const EcalRecHitCollection * recHits=0;
+	  if( ele.isEB() )
             {
-                recHits = pEBRecHits.product();
+	      recHits = pEBRecHits.product();
             } else recHits = pEERecHits.product();
-
-            SuperClusterHelper mySCHelper( &(ele), recHits, ecalTopology_, caloGeometry_ );
-
-            int elClass = -1;
-            int run = event.run();
-
-            float r9 = mySCHelper.r9();
-            double correctedEcalEnergy = ele.correctedEcalEnergy();
-            double correctedEcalEnergyError = ele.correctedEcalEnergyError();
-            double trackMomentum = ele.trackMomentumAtVtx().R();
-            double trackMomentumError = ele.trackMomentumError();
-            double combinedMomentum = ele.p();
-            double combinedMomentumError = ele.p4Error(ele.candidateP4Kind());
-            // FIXME : p4Error not filled for pure tracker electrons
-            // Recompute it using the parametrization implemented in
-            // RecoEgamma/EgammaElectronAlgos/src/ElectronEnergyCorrector.cc::simpleParameterizationUncertainty()
-            if( !ele.ecalDrivenSeed() )
+	  
+	  SuperClusterHelper mySCHelper( &(ele), recHits, ecalTopology_, caloGeometry_ );
+	  
+	  int elClass = -1;
+	  int run = event.run();
+	  
+	  float r9 = mySCHelper.r9();
+	  double correctedEcalEnergy = ele.correctedEcalEnergy();
+	  double correctedEcalEnergyError = ele.correctedEcalEnergyError();
+	  double trackMomentum = ele.trackMomentumAtVtx().R();
+	  double trackMomentumError = ele.trackMomentumError();
+	  double combinedMomentum = ele.p();
+	  double combinedMomentumError = ele.p4Error(ele.candidateP4Kind());
+	  // FIXME : p4Error not filled for pure tracker electrons
+	  // Recompute it using the parametrization implemented in
+	  // RecoEgamma/EgammaElectronAlgos/src/ElectronEnergyCorrector.cc::simpleParameterizationUncertainty()
+	  if( !ele.ecalDrivenSeed() )
             {
-                double error = 999. ;
-                double momentum = (combinedMomentum<15. ? 15. : combinedMomentum);
-                if ( ele.isEB() )
+	      double error = 999. ;
+	      double momentum = (combinedMomentum<15. ? 15. : combinedMomentum);
+	      if ( ele.isEB() )
                 {
-                    float parEB[3] = { 5.24e-02,  2.01e-01, 1.00e-02};
-                    error = momentum * sqrt( pow(parEB[0]/sqrt(momentum),2) + pow(parEB[1]/momentum,2) + pow(parEB[2],2) );
+		  float parEB[3] = { 5.24e-02,  2.01e-01, 1.00e-02};
+		  error = momentum * sqrt( pow(parEB[0]/sqrt(momentum),2) + pow(parEB[1]/momentum,2) + pow(parEB[2],2) );
                 }
-                else if ( ele.isEE() )
+	      else if ( ele.isEE() )
                 {
-                    float parEE[3] = { 1.46e-01, 9.21e-01, 1.94e-03} ;
-                    error = momentum * sqrt( pow(parEE[0]/sqrt(momentum),2) + pow(parEE[1]/momentum,2) + pow(parEE[2],2) );
+		  float parEE[3] = { 1.46e-01, 9.21e-01, 1.94e-03} ;
+		  error = momentum * sqrt( pow(parEE[0]/sqrt(momentum),2) + pow(parEE[1]/momentum,2) + pow(parEE[2],2) );
                 }
-                combinedMomentumError = error;
+	      combinedMomentumError = error;
             }
-
-            if (ele.classification() == reco::GsfElectron::GOLDEN) {elClass = 0;}
-            if (ele.classification() == reco::GsfElectron::BIGBREM) {elClass = 1;}
-            if (ele.classification() == reco::GsfElectron::BADTRACK) {elClass = 2;}
-            if (ele.classification() == reco::GsfElectron::SHOWERING) {elClass = 3;}
-            if (ele.classification() == reco::GsfElectron::GAP) {elClass = 4;}
-
-            SimpleElectron mySimpleElectron
-                (
-                    run,
-                    elClass,
-                    r9,
-                    correctedEcalEnergy,
-                    correctedEcalEnergyError,
-                    trackMomentum,
-                    trackMomentumError,
-                    regressionEnergy,
-                    regressionEnergyError,
-                    combinedMomentum,
-                    combinedMomentumError,
-                    ele.superCluster()->eta(),
-                    ele.isEB(),
-                    isMC,
-                    ele.ecalDriven(),
-                    ele.trackerDrivenSeed()
-                );
-
-            // energy calibration for ecalDriven electrons
-            if ( ele.core()->ecalDrivenSeed() || correctionsType==2 || combinationType==3 )
+	  
+	  if (ele.classification() == reco::GsfElectron::GOLDEN) {elClass = 0;}
+	  if (ele.classification() == reco::GsfElectron::BIGBREM) {elClass = 1;}
+	  if (ele.classification() == reco::GsfElectron::BADTRACK) {elClass = 2;}
+	  if (ele.classification() == reco::GsfElectron::SHOWERING) {elClass = 3;}
+	  if (ele.classification() == reco::GsfElectron::GAP) {elClass = 4;}
+	  
+	  SimpleElectron mySimpleElectron
+	    (
+	     run,
+	     elClass,
+	     r9,
+	     correctedEcalEnergy,
+	     correctedEcalEnergyError,
+	     trackMomentum,
+	     trackMomentumError,
+	     regressionEnergy,
+	     regressionEnergyError,
+	     combinedMomentum,
+	     combinedMomentumError,
+	     ele.superCluster()->eta(),
+	     ele.isEB(),
+	     isMC,
+	     ele.ecalDriven(),
+	     ele.trackerDrivenSeed()
+	     );
+	  
+	  // energy calibration for ecalDriven electrons
+	  if ( ele.core()->ecalDrivenSeed() || correctionsType==2 || combinationType==3 )
             {
-                theEnCorrector->calibrate(mySimpleElectron, event.streamID());
-
-                // E-p combination
-
-                switch ( combinationType )
+	      theEnCorrector->calibrate(mySimpleElectron, event.streamID());
+	      
+	      // E-p combination
+	      
+	      switch ( combinationType )
                 {
-                    case 0:
-                        if ( verbose )
-                        {
-                            std::cout << "[CalibratedGsfElectronProducer] "
-                            << "You choose not to combine." << std::endl;
-                        }
-                        break;
-                    case 1:
-                        if ( verbose )
-                        {
-                            std::cout << "[CalibratedGsfElectronProducer] "
-                            << "You choose corrected regression energy for standard combination" << std::endl;
-                        }
-                        myCombinator->setCombinationMode(1);
-                        myCombinator->combine(mySimpleElectron);
-                        break;
-                    case 2:
-                        if ( verbose )
-                        {
-                            std::cout << "[CalibratedGsfElectronProducer] "
-                            << "You choose uncorrected regression energy for standard combination" << std::endl;
-                        }
-                        myCombinator->setCombinationMode(2);
-                        myCombinator->combine(mySimpleElectron);
-                        break;
-                    case 3:
-                        if ( verbose )
-                        {
-                            std::cout << "[CalibratedGsfElectronProducer] "
-                            << "You choose regression combination." << std::endl;
-                        }
-                        myEpCombinationTool->combine(mySimpleElectron);
-                        theEnCorrector->correctLinearity(mySimpleElectron);
-                        break;
-                    default:
-  		                throw cms::Exception("CalibratedgsfElectronProducer|ConfigError")
-                            << "Unknown combination Type !!!" ;
+		case 0:
+		  if ( verbose )
+		    {
+		      std::cout << "[CalibratedGsfElectronProducer] "
+				<< "You choose not to combine." << std::endl;
+		    }
+		  break;
+		case 1:
+		  if ( verbose )
+		    {
+		      std::cout << "[CalibratedGsfElectronProducer] "
+				<< "You choose corrected regression energy for standard combination" << std::endl;
+		    }
+		  myCombinator->setCombinationMode(1);
+		  myCombinator->combine(mySimpleElectron);
+		  break;
+		case 2:
+		  if ( verbose )
+		    {
+		      std::cout << "[CalibratedGsfElectronProducer] "
+				<< "You choose uncorrected regression energy for standard combination" << std::endl;
+		    }
+		  myCombinator->setCombinationMode(2);
+		  myCombinator->combine(mySimpleElectron);
+		  break;
+		case 3:
+		  if ( verbose )
+		    {
+		      std::cout << "[CalibratedGsfElectronProducer] "
+				<< "You choose regression combination." << std::endl;
+		    }
+		  myEpCombinationTool->combine(mySimpleElectron);
+		  theEnCorrector->correctLinearity(mySimpleElectron);
+		  break;
+		default:
+		  throw cms::Exception("CalibratedgsfElectronProducer|ConfigError")
+		    << "Unknown combination Type !!!" ;
                 }
-
-                math::XYZTLorentzVector oldMomentum = ele.p4() ;
-                math::XYZTLorentzVector newMomentum_ ;
-                newMomentum_ = math::XYZTLorentzVector
-                 ( oldMomentum.x()*mySimpleElectron.getCombinedMomentum()/oldMomentum.t(),
-                   oldMomentum.y()*mySimpleElectron.getCombinedMomentum()/oldMomentum.t(),
-                   oldMomentum.z()*mySimpleElectron.getCombinedMomentum()/oldMomentum.t(),
-                   mySimpleElectron.getCombinedMomentum() ) ;
-
-                ele.correctMomentum
-                    (
-                        newMomentum_,
-                        mySimpleElectron.getTrackerMomentumError(),
-                        mySimpleElectron.getCombinedMomentumError()
-                    );
-
-                if ( verbose )
+	      
+	      math::XYZTLorentzVector oldMomentum = ele.p4() ;
+	      math::XYZTLorentzVector newMomentum_ ;
+	      newMomentum_ = math::XYZTLorentzVector
+		( oldMomentum.x()*mySimpleElectron.getCombinedMomentum()/oldMomentum.t(),
+		  oldMomentum.y()*mySimpleElectron.getCombinedMomentum()/oldMomentum.t(),
+		  oldMomentum.z()*mySimpleElectron.getCombinedMomentum()/oldMomentum.t(),
+		  mySimpleElectron.getCombinedMomentum() ) ;
+	      
+	      ele.correctMomentum
+		(
+		 newMomentum_,
+		 mySimpleElectron.getTrackerMomentumError(),
+		 mySimpleElectron.getCombinedMomentumError()
+		 );
+	      
+	      if ( verbose )
                 {
-                    std::cout << "[CalibratedGsfElectronProducer] Combined momentum after saving "
-                        << ele.p4().t() << std::endl;
+		  std::cout << "[CalibratedGsfElectronProducer] Combined momentum after saving "
+			    << ele.p4().t() << std::endl;
                 }
             }// end of if (ele.core()->ecalDrivenSeed())
         }// end of loop on electrons
     } else
     {
-        if ( verbose )
+      if ( verbose )
         {
-            std::cout << "[CalibratedGsfElectronProducer] "
-            << "You choose not to correct. Uncorrected Regression Energy is taken." << std::endl;
+	  std::cout << "[CalibratedGsfElectronProducer] "
+		    << "You choose not to correct. Uncorrected Regression Energy is taken." << std::endl;
         }
     }
-
-    // Save the electrons
-    const edm::OrphanHandle<reco::GsfElectronCollection> gsfNewElectronHandle = event.put(electrons, newElectronName_) ;
-    energyFiller.insert(gsfNewElectronHandle,regressionValues.begin(),regressionValues.end());
-    energyFiller.fill();
-    energyErrorFiller.insert(gsfNewElectronHandle,regressionErrorValues.begin(),regressionErrorValues.end());
-    energyErrorFiller.fill();
-
-    event.put(regrNewEnergyMap,nameNewEnergyReg_);
-    event.put(regrNewEnergyErrorMap,nameNewEnergyErrorReg_);
+  
+  // Save the electrons
+  const edm::OrphanHandle<reco::GsfElectronCollection> gsfNewElectronHandle = event.put(electrons, newElectronName_) ;
+  energyFiller.insert(gsfNewElectronHandle,regressionValues.begin(),regressionValues.end());
+  energyFiller.fill();
+  energyErrorFiller.insert(gsfNewElectronHandle,regressionErrorValues.begin(),regressionErrorValues.end());
+  energyErrorFiller.fill();
+  
+  event.put(regrNewEnergyMap,nameNewEnergyReg_);
+  event.put(regrNewEnergyErrorMap,nameNewEnergyErrorReg_);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/EgammaAnalysis/ElectronTools/plugins/CalibratedElectronProducersRun2.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/CalibratedElectronProducersRun2.cc
@@ -1,0 +1,82 @@
+#ifndef CalibratedElectronProducerRun2_h
+#define CalibratedElectronProducerRun2_h
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/PatCandidates/interface/Electron.h"
+
+#include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
+#include "CondFormats/EgammaObjects/interface/GBRForest.h"
+#include "EgammaAnalysis/ElectronTools/interface/EpCombinationTool.h"
+#include "EgammaAnalysis/ElectronTools/interface/ElectronEnergyCalibratorRun2.h"
+
+#include <vector>
+
+template<typename T>
+class CalibratedElectronProducerRun2T: public edm::stream::EDProducer<>
+{
+    public:
+        explicit CalibratedElectronProducerRun2T( const edm::ParameterSet & ) ;
+        virtual ~CalibratedElectronProducerRun2T();
+        virtual void produce( edm::Event &, const edm::EventSetup & ) override ;
+
+    private:
+        edm::EDGetTokenT<edm::View<T> > theElectronToken;
+        std::string theGBRForestName;
+        edm::ESHandle<GBRForest> theGBRForestHandle;
+
+        EpCombinationTool theEpCombinationTool;
+        ElectronEnergyCalibratorRun2 theEnCorrectorRun2;
+};
+
+template<typename T>
+CalibratedElectronProducerRun2T<T>::CalibratedElectronProducerRun2T( const edm::ParameterSet & conf ) :
+  theElectronToken(consumes<edm::View<T> >(conf.getParameter<edm::InputTag>("electrons"))),
+  theGBRForestName(conf.getParameter<std::string>("gbrForestName")),
+  theEpCombinationTool(),
+  theEnCorrectorRun2(theEpCombinationTool, conf.getParameter<bool>("isMC"), conf.getParameter<bool>("isSynchronization"), conf.getParameter<std::vector<double> >("smearings"), conf.getParameter<std::vector<double> >("scales"))
+{
+  produces<std::vector<T> >();
+}
+
+template<typename T>
+CalibratedElectronProducerRun2T<T>::~CalibratedElectronProducerRun2T()
+{
+}
+
+template<typename T>
+void
+CalibratedElectronProducerRun2T<T>::produce( edm::Event & iEvent, const edm::EventSetup & iSetup ) 
+{
+    iSetup.get<GBRWrapperRcd>().get(theGBRForestName, theGBRForestHandle);
+    theEpCombinationTool.init(theGBRForestHandle.product());
+
+    edm::Handle<edm::View<T> > in;
+    iEvent.getByToken(theElectronToken, in);
+
+    std::auto_ptr<std::vector<T> > out(new std::vector<T>());
+    out->reserve(in->size());   
+
+    for (const T &ele : *in) {
+        out->push_back(ele);
+        theEnCorrectorRun2.calibrate(out->back(), iEvent.id().run(), iEvent.streamID());
+    }
+    
+    iEvent.put(out);
+}
+
+typedef CalibratedElectronProducerRun2T<reco::GsfElectron> CalibratedElectronProducerRun2;
+typedef CalibratedElectronProducerRun2T<pat::Electron> CalibratedPatElectronProducerRun2;
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+DEFINE_FWK_MODULE(CalibratedElectronProducerRun2);
+DEFINE_FWK_MODULE(CalibratedPatElectronProducerRun2);
+
+#endif

--- a/EgammaAnalysis/ElectronTools/plugins/CalibratedPatElectronProducer.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/CalibratedPatElectronProducer.cc
@@ -39,15 +39,9 @@
 
 #include <iostream>
 
-using namespace edm ;
-using namespace std ;
-using namespace reco ;
-using namespace pat ;
-
 CalibratedPatElectronProducer::CalibratedPatElectronProducer( const edm::ParameterSet & cfg )
-// : PatElectronBaseProducer(cfg)
 {
-    produces<ElectronCollection>();
+  produces<pat::ElectronCollection>();
 
     inputPatElectronsToken = consumes<edm::View<reco::Candidate> >(cfg.getParameter<edm::InputTag>("inputPatElectronsTag"));
     dataset = cfg.getParameter<std::string>("inputDataset");
@@ -160,9 +154,9 @@ void CalibratedPatElectronProducer::produce( edm::Event & event, const edm::Even
 
     edm::Handle<edm::View<reco::Candidate> > oldElectrons ;
     event.getByToken(inputPatElectronsToken,oldElectrons) ;
-    std::auto_ptr<ElectronCollection> electrons( new ElectronCollection ) ;
-    ElectronCollection::const_iterator electron ;
-    ElectronCollection::iterator ele ;
+    std::auto_ptr<pat::ElectronCollection> electrons( new pat::ElectronCollection ) ;
+    pat::ElectronCollection::const_iterator electron ;
+    pat::ElectronCollection::iterator ele ;
     // first clone the initial collection
     for
         (
@@ -195,7 +189,7 @@ void CalibratedPatElectronProducer::produce( edm::Event & event, const edm::Even
             double trackMomentumError = ele->trackMomentumError();
             double combinedMomentum = ele->p();
             double combinedMomentumError = 0;
-            if ( ele->candidateP4Kind() != GsfElectron::P4_UNKNOWN )
+            if ( ele->candidateP4Kind() != reco::GsfElectron::P4_UNKNOWN )
             {
               combinedMomentumError = ele->p4Error(ele->candidateP4Kind());
             }

--- a/EgammaAnalysis/ElectronTools/plugins/CalibratedPhotonProducersRun2.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/CalibratedPhotonProducersRun2.cc
@@ -1,0 +1,66 @@
+#ifndef CalibratedPhotonProducer_h
+#define CalibratedPhotonProducer_h
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/EgammaCandidates/interface/Photon.h"
+#include "DataFormats/PatCandidates/interface/Photon.h"
+#include "EgammaAnalysis/ElectronTools/interface/PhotonEnergyCalibratorRun2.h"
+
+#include <vector>
+
+template<typename T>
+class CalibratedPhotonProducerRun2T: public edm::stream::EDProducer<> {
+public:
+  explicit CalibratedPhotonProducerRun2T( const edm::ParameterSet & ) ;
+  virtual ~CalibratedPhotonProducerRun2T();
+  virtual void produce( edm::Event &, const edm::EventSetup & ) override ;
+
+private:
+  edm::EDGetTokenT<edm::View<T> > thePhotonToken;
+  PhotonEnergyCalibratorRun2 theEnCorrectorRun2;
+};
+
+template<typename T>
+CalibratedPhotonProducerRun2T<T>::CalibratedPhotonProducerRun2T( const edm::ParameterSet & conf ) :
+  thePhotonToken(consumes<edm::View<T> >(conf.getParameter<edm::InputTag>("photons"))),
+  theEnCorrectorRun2(conf.getParameter<bool>("isMC"), conf.getParameter<bool>("isSynchronization"), conf.getParameter<std::vector<double> >("smearings"), conf.getParameter<std::vector<double> >("scales")) {
+  produces<std::vector<T> >();
+}
+
+template<typename T>
+CalibratedPhotonProducerRun2T<T>::~CalibratedPhotonProducerRun2T()
+{}
+
+template<typename T>
+void
+CalibratedPhotonProducerRun2T<T>::produce( edm::Event & iEvent, const edm::EventSetup & iSetup ) {
+
+  edm::Handle<edm::View<T> > in;
+  iEvent.getByToken(thePhotonToken, in);
+
+  std::auto_ptr<std::vector<T> > out(new std::vector<T>());
+  out->reserve(in->size());   
+  
+  for (const T &ele : *in) {
+    out->push_back(ele);
+    theEnCorrectorRun2.calibrate(out->back(), iEvent.id().run(), iEvent.streamID());
+  }
+    
+  iEvent.put(out);
+}
+
+typedef CalibratedPhotonProducerRun2T<reco::Photon> CalibratedPhotonProducerRun2;
+typedef CalibratedPhotonProducerRun2T<pat::Photon> CalibratedPatPhotonProducerRun2;
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+DEFINE_FWK_MODULE(CalibratedPhotonProducerRun2);
+DEFINE_FWK_MODULE(CalibratedPatPhotonProducerRun2);
+
+#endif

--- a/EgammaAnalysis/ElectronTools/plugins/ElectronIdMVAProducer.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/ElectronIdMVAProducer.cc
@@ -21,8 +21,6 @@
 // class declaration
 //
 
-using namespace std;
-using namespace reco;
 class ElectronIdMVAProducer : public edm::EDFilter {
 public:
   explicit ElectronIdMVAProducer(const edm::ParameterSet&);
@@ -40,8 +38,8 @@ private:
   edm::EDGetTokenT<EcalRecHitCollection> reducedEERecHitCollectionToken_;
   
   double _Rho;
-  string method_;
-  vector<string> mvaWeightFiles_;
+  std::string method_;
+  std::vector<std::string> mvaWeightFiles_;
   bool Trig_;
   bool NoIP_;
   
@@ -66,8 +64,8 @@ ElectronIdMVAProducer::ElectronIdMVAProducer(const edm::ParameterSet& iConfig) {
   eventrhoToken_ = consumes<double>(edm::InputTag("kt6PFJets", "rho"));
   reducedEBRecHitCollectionToken_ = consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("reducedEBRecHitCollection"));
   reducedEERecHitCollectionToken_ = consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("reducedEERecHitCollection"));
-  method_ = iConfig.getParameter<string>("method");
-  std::vector<string> fpMvaWeightFiles = iConfig.getParameter<std::vector<std::string> >("mvaWeightFile");
+  method_ = iConfig.getParameter<std::string>("method");
+  std::vector<std::string> fpMvaWeightFiles = iConfig.getParameter<std::vector<std::string> >("mvaWeightFile");
   Trig_ = iConfig.getParameter<bool>("Trig");
   NoIP_ = iConfig.getParameter<bool>("NoIP");
   
@@ -84,7 +82,7 @@ ElectronIdMVAProducer::ElectronIdMVAProducer(const edm::ParameterSet& iConfig) {
   
   bool manualCat_ = true;
   
-  string path_mvaWeightFileEleID;
+  std::string path_mvaWeightFileEleID;
   for(unsigned ifile=0 ; ifile < fpMvaWeightFiles.size() ; ++ifile) {
     path_mvaWeightFileEleID = edm::FileInPath ( fpMvaWeightFiles[ifile].c_str() ).fullPath();
     mvaWeightFiles_.push_back(path_mvaWeightFileEleID);
@@ -110,24 +108,23 @@ ElectronIdMVAProducer::~ElectronIdMVAProducer()
 
 // ------------ method called on each new Event  ------------
 bool ElectronIdMVAProducer::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  using namespace edm;
-  
+
   std::auto_ptr<edm::ValueMap<float> > out(new edm::ValueMap<float>() );
   
-  Handle<reco::VertexCollection>  vertexCollection;
+  edm::Handle<reco::VertexCollection>  vertexCollection;
   iEvent.getByToken(vertexToken_, vertexCollection);
   
-  Vertex dummy;
-  const Vertex *pv = &dummy;
+  reco::Vertex dummy;
+  const reco::Vertex *pv = &dummy;
   if ( vertexCollection->size() != 0) {
     pv = &*vertexCollection->begin();
   } else { // create a dummy PV
-    Vertex::Error e;
+    reco::Vertex::Error e;
     e(0, 0) = 0.0015 * 0.0015;
     e(1, 1) = 0.0015 * 0.0015;
     e(2, 2) = 15. * 15.;
-    Vertex::Point p(0, 0, 0);
-    dummy = Vertex(p, e, 0, 0, 0);
+    reco::Vertex::Point p(0, 0, 0);
+    dummy = reco::Vertex(p, e, 0, 0, 0);
   }
   
   EcalClusterLazyTools lazyTools(iEvent, iSetup, reducedEBRecHitCollectionToken_, reducedEERecHitCollectionToken_);
@@ -136,7 +133,7 @@ bool ElectronIdMVAProducer::filter(edm::Event& iEvent, const edm::EventSetup& iS
   iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", builder);
   TransientTrackBuilder thebuilder = *(builder.product());
   
-  Handle<reco::GsfElectronCollection> egCollection;
+  edm::Handle<reco::GsfElectronCollection> egCollection;
   iEvent.getByToken(electronToken_,egCollection);
   const reco::GsfElectronCollection egCandidates = (*egCollection.product());
   

--- a/EgammaAnalysis/ElectronTools/plugins/ElectronPATIdMVAProducer.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/ElectronPATIdMVAProducer.cc
@@ -21,8 +21,6 @@
 // class declaration
 //
 
-using namespace std;
-using namespace reco;
 class ElectronPATIdMVAProducer : public edm::EDProducer {
 	public:
 		explicit ElectronPATIdMVAProducer(const edm::ParameterSet&);
@@ -36,8 +34,8 @@ class ElectronPATIdMVAProducer : public edm::EDProducer {
   edm::EDGetTokenT<pat::ElectronCollection> electronToken_;
   double _Rho;
   edm::EDGetTokenT<double> eventrhoToken_;
-  string method_;
-  vector<string> mvaWeightFiles_;
+  std::string method_;
+  std::vector<std::string> mvaWeightFiles_;
 
 
   EGammaMvaEleEstimator* mvaID_;
@@ -58,8 +56,8 @@ class ElectronPATIdMVAProducer : public edm::EDProducer {
 ElectronPATIdMVAProducer::ElectronPATIdMVAProducer(const edm::ParameterSet& iConfig) {
         verbose_ = iConfig.getUntrackedParameter<bool>("verbose", false);
 	electronToken_ = consumes<pat::ElectronCollection>(iConfig.getParameter<edm::InputTag>("electronTag"));
-	method_ = iConfig.getParameter<string>("method");
-	std::vector<string> fpMvaWeightFiles = iConfig.getParameter<std::vector<std::string> >("mvaWeightFile");
+	method_ = iConfig.getParameter<std::string>("method");
+	std::vector<std::string> fpMvaWeightFiles = iConfig.getParameter<std::vector<std::string> >("mvaWeightFile");
 	eventrhoToken_ = consumes<double>(iConfig.getParameter<edm::InputTag>("Rho"));
 
         produces<edm::ValueMap<float> >();
@@ -75,7 +73,7 @@ ElectronPATIdMVAProducer::ElectronPATIdMVAProducer(const edm::ParameterSet& iCon
 
         bool manualCat_ = true;
 
-	string path_mvaWeightFileEleID;
+	std::string path_mvaWeightFileEleID;
 	for(unsigned ifile=0 ; ifile < fpMvaWeightFiles.size() ; ++ifile) {
 	  path_mvaWeightFileEleID = edm::FileInPath ( fpMvaWeightFiles[ifile].c_str() ).fullPath();
 	  mvaWeightFiles_.push_back(path_mvaWeightFileEleID);
@@ -101,7 +99,6 @@ ElectronPATIdMVAProducer::~ElectronPATIdMVAProducer()
 
 // ------------ method called on each new Event  ------------
 void ElectronPATIdMVAProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-	using namespace edm;
 
         std::auto_ptr<edm::ValueMap<float> > out(new edm::ValueMap<float>() );
 
@@ -111,7 +108,7 @@ void ElectronPATIdMVAProducer::produce(edm::Event& iEvent, const edm::EventSetup
 
 
 
-	Handle<pat::ElectronCollection> egCollection;
+	edm::Handle<pat::ElectronCollection> egCollection;
 	iEvent.getByToken(electronToken_,egCollection);
         const pat::ElectronCollection egCandidates = (*egCollection.product());
 

--- a/EgammaAnalysis/ElectronTools/plugins/ElectronRegressionEnergyProducer.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/ElectronRegressionEnergyProducer.cc
@@ -27,10 +27,6 @@
 // class declaration
 //
 
-using namespace std;
-using namespace reco;
-using namespace edm;
-
 class ElectronRegressionEnergyProducer : public edm::EDFilter {
 public:
   explicit ElectronRegressionEnergyProducer(const edm::ParameterSet&);
@@ -127,7 +123,7 @@ bool ElectronRegressionEnergyProducer::filter(edm::Event& iEvent, const edm::Eve
   std::auto_ptr<edm::ValueMap<double> > regrEnergyErrorMap(new edm::ValueMap<double>() );
   edm::ValueMap<double>::Filler energyErrorFiller(*regrEnergyErrorMap);
 
-  Handle<reco::GsfElectronCollection> egCollection;
+  edm::Handle<reco::GsfElectronCollection> egCollection;
   iEvent.getByToken(electronToken_,egCollection);
   const reco::GsfElectronCollection egCandidates = (*egCollection.product());
 
@@ -147,7 +143,7 @@ bool ElectronRegressionEnergyProducer::filter(edm::Event& iEvent, const edm::Eve
   //**************************************************************************
   //Get Number of Vertices
   //**************************************************************************
-  Handle<reco::VertexCollection> hVertexProduct;
+  edm::Handle<reco::VertexCollection> hVertexProduct;
   iEvent.getByToken(hVertexToken_,hVertexProduct);
   const reco::VertexCollection inVertices = *(hVertexProduct.product());
 
@@ -169,7 +165,7 @@ bool ElectronRegressionEnergyProducer::filter(edm::Event& iEvent, const edm::Eve
   //Get Rho
   //**************************************************************************
   double rho = 0;
-  Handle<double> hRhoKt6PFJets;
+  edm::Handle<double> hRhoKt6PFJets;
   iEvent.getByToken(hRhoKt6PFJetsToken_, hRhoKt6PFJets);
   rho = (*hRhoKt6PFJets);
 

--- a/EgammaAnalysis/ElectronTools/plugins/GBRForestGetterFromDB.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/GBRForestGetterFromDB.cc
@@ -1,0 +1,54 @@
+#ifndef CalibratedElectronProducer_h
+#define CalibratedElectronProducer_h
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
+#include "CondFormats/EgammaObjects/interface/GBRForest.h"
+#include <TFile.h>
+
+
+class GBRForestGetterFromDB: public edm::one::EDAnalyzer<>
+{
+    public:
+        explicit GBRForestGetterFromDB( const edm::ParameterSet & ) ;
+        virtual ~GBRForestGetterFromDB() ;
+        virtual void analyze( const edm::Event &, const edm::EventSetup & ) override ;
+
+    private:
+        std::string theGBRForestName;
+        std::string theOutputFileName;
+        std::string theOutputObjectName;
+        edm::ESHandle<GBRForest> theGBRForestHandle;
+};
+
+GBRForestGetterFromDB::GBRForestGetterFromDB( const edm::ParameterSet & conf ) :
+    theGBRForestName(conf.getParameter<std::string>("grbForestName")),
+    theOutputFileName(conf.getUntrackedParameter<std::string>("outputFileName")),
+    theOutputObjectName(conf.getUntrackedParameter<std::string>("outputObjectName", theGBRForestName.empty() ? "GBRForest" : theGBRForestName))
+{
+}
+
+GBRForestGetterFromDB::~GBRForestGetterFromDB()
+{
+}
+
+void
+GBRForestGetterFromDB::analyze( const edm::Event & iEvent, const edm::EventSetup & iSetup ) 
+{
+    iSetup.get<GBRWrapperRcd>().get(theGBRForestName, theGBRForestHandle);
+    TFile *fOut = TFile::Open(theOutputFileName.c_str(), "RECREATE");
+    fOut->WriteObject(theGBRForestHandle.product(), theOutputObjectName.c_str());
+    fOut->Close();
+    std::cout << "Wrote output to " << theOutputFileName << std::endl;
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(GBRForestGetterFromDB);
+
+#endif

--- a/EgammaAnalysis/ElectronTools/plugins/PhotonIsoProducer.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/PhotonIsoProducer.cc
@@ -22,8 +22,6 @@
 // class declaration
 //
 
-using namespace std;
-using namespace reco;
 class PhotonIsoProducer : public edm::EDFilter {
       public:
          explicit PhotonIsoProducer(const edm::ParameterSet&);
@@ -90,7 +88,6 @@ PhotonIsoProducer::~PhotonIsoProducer()
 
 // ------------ method called on each new Event  ------------
 bool PhotonIsoProducer::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-	using namespace edm;
 
         std::auto_ptr<edm::ValueMap<double> > chIsoMap(new edm::ValueMap<double>() );
 	edm::ValueMap<double>::Filler chFiller(*chIsoMap);
@@ -101,17 +98,17 @@ bool PhotonIsoProducer::filter(edm::Event& iEvent, const edm::EventSetup& iSetup
         std::auto_ptr<edm::ValueMap<double> > nhIsoMap(new edm::ValueMap<double>() );
 	edm::ValueMap<double>::Filler nhFiller(*nhIsoMap);
 
-	Handle<reco::VertexCollection>  vertexCollection;
+	edm::Handle<reco::VertexCollection>  vertexCollection;
 	iEvent.getByToken(vertexToken_, vertexCollection);
 
-	Handle<reco::PhotonCollection> phoCollection;
+	edm::Handle<reco::PhotonCollection> phoCollection;
 	iEvent.getByToken(photonToken_, phoCollection);
 	const reco::PhotonCollection *recoPho = phoCollection.product();
 
 	// All PF Candidate for alternate isolation
-	Handle<reco::PFCandidateCollection> pfCandidatesH;
+	edm::Handle<reco::PFCandidateCollection> pfCandidatesH;
 	iEvent.getByToken(particleFlowToken_, pfCandidatesH);
-	const  PFCandidateCollection thePfColl = *(pfCandidatesH.product());
+	const  reco::PFCandidateCollection thePfColl = *(pfCandidatesH.product());
 
         std::vector<double> chIsoValues;
 	std::vector<double> phIsoValues;
@@ -121,7 +118,7 @@ bool PhotonIsoProducer::filter(edm::Event& iEvent, const edm::EventSetup& iSetup
         nhIsoValues.reserve(phoCollection->size());
 
 	unsigned int ivtx = 0;
-	VertexRef myVtxRef(vertexCollection, ivtx);
+	reco::VertexRef myVtxRef(vertexCollection, ivtx);
 
 
         for (reco::PhotonCollection::const_iterator aPho = recoPho->begin(); aPho != recoPho->end(); ++aPho) {

--- a/EgammaAnalysis/ElectronTools/plugins/RegressionEnergyPatElectronProducer.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/RegressionEnergyPatElectronProducer.cc
@@ -14,20 +14,14 @@
 
 #include <iostream>
 
-using namespace edm ;
-using namespace std ;
-using namespace reco ;
-using namespace pat ;
-
-
 RegressionEnergyPatElectronProducer::RegressionEnergyPatElectronProducer( const edm::ParameterSet & cfg )
 {
 
-  inputGsfElectronsToken_ = mayConsume<GsfElectronCollection>(cfg.getParameter<edm::InputTag>("inputElectronsTag"));
-  inputPatElectronsToken_ = mayConsume<ElectronCollection>(cfg.getParameter<edm::InputTag>("inputElectronsTag"));
+  inputGsfElectronsToken_ = mayConsume<reco::GsfElectronCollection>(cfg.getParameter<edm::InputTag>("inputElectronsTag"));
+  inputPatElectronsToken_ = mayConsume<pat::ElectronCollection>(cfg.getParameter<edm::InputTag>("inputElectronsTag"));
   inputCollectionType_ = cfg.getParameter<uint32_t>("inputCollectionType");
   rhoInputToken_ = consumes<double>(cfg.getParameter<edm::InputTag>("rhoCollection"));
-  verticesInputToken_ = consumes<VertexCollection>(cfg.getParameter<edm::InputTag>("vertexCollection"));
+  verticesInputToken_ = consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("vertexCollection"));
   energyRegressionType_ = cfg.getParameter<uint32_t>("energyRegressionType");
   regressionInputFile_ = cfg.getParameter<std::string>("regressionInputFile");
   recHitCollectionEBToken_ = mayConsume<EcalRecHitCollection>(cfg.getParameter<edm::InputTag>("recHitCollectionEB"));
@@ -50,7 +44,7 @@ RegressionEnergyPatElectronProducer::RegressionEnergyPatElectronProducer( const 
   if (inputCollectionType_ == 0) {
     // do nothing
   } else if (inputCollectionType_ == 1) {
-    produces<ElectronCollection>();
+    produces<pat::ElectronCollection>();
   } else {
     throw cms::Exception("InconsistentParameters")  << " inputCollectionType should be either 0 (GsfElectrons) or 1 (pat::Electrons) " << std::endl;
   }
@@ -107,7 +101,7 @@ void RegressionEnergyPatElectronProducer::produce( edm::Event & event, const edm
   //**************************************************************************
   //Get Number of Vertices
   //**************************************************************************
-  Handle<reco::VertexCollection> hVertexProduct;
+  edm::Handle<reco::VertexCollection> hVertexProduct;
   event.getByToken(verticesInputToken_,hVertexProduct);
   const reco::VertexCollection inVertices = *(hVertexProduct.product());
 
@@ -129,7 +123,7 @@ void RegressionEnergyPatElectronProducer::produce( edm::Event & event, const edm
   //Get Rho
   //**************************************************************************
   double rho = 0;
-  Handle<double> hRhoKt6PFJets;
+  edm::Handle<double> hRhoKt6PFJets;
   event.getByToken(rhoInputToken_, hRhoKt6PFJets);
   rho = (*hRhoKt6PFJets);
 
@@ -144,8 +138,8 @@ void RegressionEnergyPatElectronProducer::produce( edm::Event & event, const edm
     event.getByToken( recHitCollectionEEToken_, pEERecHits );
   }
 
-  edm::Handle<GsfElectronCollection> gsfCollectionH ;
-  edm::Handle<ElectronCollection> patCollectionH;
+  edm::Handle<reco::GsfElectronCollection> gsfCollectionH ;
+  edm::Handle<pat::ElectronCollection> patCollectionH;
   if ( inputCollectionType_ == 0 ) {
     event.getByToken ( inputGsfElectronsToken_,gsfCollectionH )  ;
     nElectrons_ = gsfCollectionH->size();
@@ -156,7 +150,7 @@ void RegressionEnergyPatElectronProducer::produce( edm::Event & event, const edm
   }
 
   // prepare the two even if only one is used
-  std::auto_ptr<ElectronCollection> patElectrons( new ElectronCollection ) ;
+  std::auto_ptr<pat::ElectronCollection> patElectrons( new pat::ElectronCollection ) ;
 
   // Fillers for ValueMaps:
   std::auto_ptr<edm::ValueMap<double> > regrEnergyMap(new edm::ValueMap<double>() );
@@ -175,7 +169,7 @@ void RegressionEnergyPatElectronProducer::produce( edm::Event & event, const edm
 
   for(unsigned iele=0; iele < nElectrons_ ; ++iele) {
 
-    const GsfElectron * ele = ( inputCollectionType_ == 0 ) ? &(*gsfCollectionH)[iele] : &(*patCollectionH)[iele] ;
+    const reco::GsfElectron * ele = ( inputCollectionType_ == 0 ) ? &(*gsfCollectionH)[iele] : &(*patCollectionH)[iele] ;
     if (debug_) {
       std::cout << "***********************************************************************\n";
       std::cout << "Run Lumi Event: " << event.id().run() << " " << event.luminosityBlock() << " " << event.id().event() << "\n";
@@ -536,7 +530,7 @@ void RegressionEnergyPatElectronProducer::produce( edm::Event & event, const edm
 	energyValues.push_back(RegressionMomentum);
 	energyErrorValues.push_back(RegressionMomentumError);
       } else {
-	cout << "Error: RegressionType = " << energyRegressionType_ << " is not supported.\n";
+	std::cout << "Error: RegressionType = " << energyRegressionType_ << " is not supported.\n";
       }
 
       if(inputCollectionType_ == 1) {

--- a/EgammaAnalysis/ElectronTools/python/calibratedElectronsRun2_cfi.py
+++ b/EgammaAnalysis/ElectronTools/python/calibratedElectronsRun2_cfi.py
@@ -1,0 +1,55 @@
+import FWCore.ParameterSet.Config as cms
+
+correctionType = "Prompt2015"
+# THE FOLLOWING VALUES ARE THOSE FOR 2015 PROMPT RECO 
+# the array follows this parametrization:
+#  (0.0    <= aeta && aeta < 1.0    && bad )
+#  (0.0    <= aeta && aeta < 1.0    && gold)
+#  (1.0    <= aeta && aeta < 1.4442 && bad )
+#  (1.0    <= aeta && aeta < 1.4442 && gold)
+#  (1.566  <= aeta && aeta < 2.0    && bad )
+#  (1.566  <= aeta && aeta < 2.0    && gold)
+#  (2.0    <= aeta && aeta < 2.5    && bad )
+#  (2.0    <= aeta && aeta < 2.5    && gold)
+#use the 1.566-2.0 also for the 1.4442-1.566 area, in the lack of a new correction
+#  (1.4442 <= aeta && aeta < 1.566  && bad )
+#  (1.4442 <= aeta && aeta < 1.566  && gold)
+smearingList = {"Prompt2015":cms.vdouble(0.013654,0.014142,0.020859,0.017120,0.028083,0.027289,0.031793,0.030831,0.028083, 0.027289)}
+scaleList    = {"Prompt2015":cms.vdouble(0.99544,0.99882,0.99662,1.0065,0.98633,0.99536,0.97859,0.98567,0.98633, 0.99536)}
+
+calibratedElectrons = cms.EDProducer("CalibratedElectronProducerRun2",
+
+                                     # input collections
+                                     electrons = cms.InputTag('gedGsfElectrons'),
+                                     gbrForestName = cms.string("gedelectron_p4combination_25ns"),
+
+                                     # data or MC corrections
+                                     # if isMC is false, data corrections are applied
+                                     isMC = cms.bool(False),
+    
+                                     # set to True to get special "fake" smearing for synchronization. Use JUST in case of synchronization
+                                     isSynchronization = cms.bool(False),
+                                     
+                                     smearings = smearingList[correctionType],
+                                     scales = scaleList[correctionType]
+                                     )
+
+
+calibratedPatElectrons = cms.EDProducer("CalibratedPatElectronProducerRun2",
+                                        
+                                        # input collections
+                                        electrons = cms.InputTag('slimmedElectrons'),
+                                        gbrForestName = cms.string("gedelectron_p4combination_25ns"),
+                                        
+                                        # data or MC corrections
+                                        # if isMC is false, data corrections are applied
+                                        isMC = cms.bool(False),
+                                        
+                                        # set to True to get special "fake" smearing for synchronization. Use JUST in case of synchronization
+                                        isSynchronization = cms.bool(False),
+
+                                        smearings = smearingList[correctionType],
+                                        scales = scaleList[correctionType]
+                                        )
+
+

--- a/EgammaAnalysis/ElectronTools/python/calibratedPhotonsRun2_cfi.py
+++ b/EgammaAnalysis/ElectronTools/python/calibratedPhotonsRun2_cfi.py
@@ -1,0 +1,53 @@
+
+import FWCore.ParameterSet.Config as cms
+
+correctionType = "Prompt2015"
+# THE FOLLOWING VALUES ARE THOSE FOR 2015 PROMPT RECO 
+# the array follows this parametrization:
+#  (0.0    <= aeta && aeta < 1.0    && bad )
+#  (0.0    <= aeta && aeta < 1.0    && gold)
+#  (1.0    <= aeta && aeta < 1.4442 && bad )
+#  (1.0    <= aeta && aeta < 1.4442 && gold)
+#  (1.566  <= aeta && aeta < 2.0    && bad )
+#  (1.566  <= aeta && aeta < 2.0    && gold)
+#  (2.0    <= aeta && aeta < 2.5    && bad )
+#  (2.0    <= aeta && aeta < 2.5    && gold)
+#use the 1.566-2.0 also for the 1.4442-1.566 area, in the lack of a new correction
+#  (1.4442 <= aeta && aeta < 1.566  && bad )
+#  (1.4442 <= aeta && aeta < 1.566  && gold)
+smearingList = {"Prompt2015":cms.vdouble(0.013654,0.014142,0.020859,0.017120,0.028083,0.027289,0.031793,0.030831,0.028083, 0.027289)}
+scaleList    = {"Prompt2015":cms.vdouble(0.99544,0.99882,0.99662,1.0065,0.98633,0.99536,0.97859,0.98567,0.98633, 0.99536)}
+
+calibratedPatPhotons = cms.EDProducer("CalibratedPatPhotonProducerRun2",
+
+                                      # input collections
+                                      photons = cms.InputTag('slimmedPhotons'),
+                                      
+                                      # data or MC corrections
+                                      # if isMC is false, data corrections are applied
+                                      isMC = cms.bool(False),
+                                      
+                                      # set to True to get special "fake" smearing for synchronization. Use JUST in case of synchronization
+                                      isSynchronization = cms.bool(False),
+                                      
+                                      smearings = smearingList[correctionType],
+                                      scales = scaleList[correctionType],                                      
+                                      )
+
+calibratedPhotons = cms.EDProducer("CalibratedPhotonProducerRun2",
+
+                                   # input collections
+                                   photons = cms.InputTag('photons'),
+                                   
+                                   # data or MC corrections
+                                   # if isMC is false, data corrections are applied
+                                   isMC = cms.bool(False),
+                                   
+                                   # set to True to get special "fake" smearing for synchronization. Use JUST in case of synchronization
+                                   isSynchronization = cms.bool(False),
+
+                                   smearings = smearingList[correctionType],
+                                   scales = scaleList[correctionType]
+                                   )
+
+

--- a/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimator.cc
+++ b/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimator.cc
@@ -2,7 +2,6 @@
 #include "EgammaAnalysis/ElectronTools/interface/EGammaMvaEleEstimator.h"
 #include <cmath>
 #include <vector>
-using namespace std;
 
 #ifndef STANDALONE
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -22,7 +21,6 @@ using namespace std;
 #include "DataFormats/Common/interface/RefToPtr.h"
 #include <cstdio>
 #include <zlib.h>
-using namespace reco;
 #endif
 
 //--------------------------------------------------------------------------------------------------
@@ -486,7 +484,7 @@ Double_t EGammaMvaEleEstimator::mvaValue(Double_t fbrem,
   }
 
   if (fMVAType != EGammaMvaEleEstimator::kTrig) {
-    std::cout << "Error: This method should be called for kTrig MVA only" << endl;
+    std::cout << "Error: This method should be called for kTrig MVA only" <<std::endl;
     return -9999;
   }
 
@@ -530,8 +528,8 @@ Double_t EGammaMvaEleEstimator::mvaValue(Double_t fbrem,
   }
 
   if(printDebug) {
-    cout << " *** Inside the class fMethodname " << fMethodname << endl;
-    cout << " fbrem " <<  fMVAVar_fbrem  
+    std::cout << " *** Inside the class fMethodname " << fMethodname << std::endl;
+    std::cout << " fbrem " <<  fMVAVar_fbrem  
       	 << " kfchi2 " << fMVAVar_kfchi2  
 	 << " mykfhits " << fMVAVar_kfhits  
 	 << " gsfchi2 " << fMVAVar_gsfchi2  
@@ -552,8 +550,8 @@ Double_t EGammaMvaEleEstimator::mvaValue(Double_t fbrem,
 	 << " d0 " << fMVAVar_d0  
 	 << " ip3d " << fMVAVar_ip3d  
 	 << " eta " << fMVAVar_eta  
-	 << " pt " << fMVAVar_pt << endl;
-    cout << " ### MVA " << mva << endl;
+	 << " pt " << fMVAVar_pt <<std::endl;
+    std::cout << " ### MVA " << mva << std::endl;
   }
 
 
@@ -591,7 +589,7 @@ Double_t EGammaMvaEleEstimator::mvaValue(Double_t fbrem,
   }
 
   if (fMVAType != EGammaMvaEleEstimator::kTrigNoIP) {
-    std::cout << "Error: This method should be called for kTrigNoIP MVA only" << endl;
+    std::cout << "Error: This method should be called for kTrigNoIP MVA only" <<std::endl;
     return -9999;
   }
 
@@ -633,8 +631,8 @@ Double_t EGammaMvaEleEstimator::mvaValue(Double_t fbrem,
   }
 
   if(printDebug) {
-    cout << " *** Inside the class fMethodname " << fMethodname << endl;
-    cout << " fbrem " <<  fMVAVar_fbrem  
+    std::cout << " *** Inside the class fMethodname " << fMethodname << std::endl;
+    std::cout << " fbrem " <<  fMVAVar_fbrem  
       	 << " kfchi2 " << fMVAVar_kfchi2  
 	 << " mykfhits " << fMVAVar_kfhits  
 	 << " gsfchi2 " << fMVAVar_gsfchi2  
@@ -654,8 +652,8 @@ Double_t EGammaMvaEleEstimator::mvaValue(Double_t fbrem,
 	 << " rho " << fMVAVar_rho 
 	 << " PreShowerOverRaw " << fMVAVar_PreShowerOverRaw  
        	 << " eta " << fMVAVar_eta  
-	 << " pt " << fMVAVar_pt << endl;
-    cout << " ### MVA " << mva << endl;
+	 << " pt " << fMVAVar_pt <<std::endl;
+    std::cout << " ### MVA " << mva << std::endl;
   }
 
 
@@ -695,7 +693,7 @@ Double_t EGammaMvaEleEstimator::mvaValue(Double_t fbrem,
   }
 
   if (fMVAType != EGammaMvaEleEstimator::kNonTrig) {
-    std::cout << "Error: This method should be called for kNonTrig MVA only" << endl;
+    std::cout << "Error: This method should be called for kNonTrig MVA only" <<std::endl;
     return -9999;
   }
 
@@ -739,8 +737,8 @@ Double_t EGammaMvaEleEstimator::mvaValue(Double_t fbrem,
 
 
   if(printDebug) {
-    cout << " *** Inside the class fMethodname " << fMethodname << endl;
-    cout << " fbrem " <<  fMVAVar_fbrem  
+    std::cout << " *** Inside the class fMethodname " << fMethodname << std::endl;
+    std::cout << " fbrem " <<  fMVAVar_fbrem  
       	 << " kfchi2 " << fMVAVar_kfchi2  
 	 << " mykfhits " << fMVAVar_kfhits  
 	 << " gsfchi2 " << fMVAVar_gsfchi2  
@@ -759,8 +757,8 @@ Double_t EGammaMvaEleEstimator::mvaValue(Double_t fbrem,
 	 << " eleEoPout " << fMVAVar_eleEoPout  
 	 << " PreShowerOverRaw " << fMVAVar_PreShowerOverRaw  
 	 << " eta " << fMVAVar_eta  
-	 << " pt " << fMVAVar_pt << endl;
-    cout << " ### MVA " << mva << endl;
+	 << " pt " << fMVAVar_pt <<std::endl;
+    std::cout << " ### MVA " << mva << std::endl;
   }
 
 
@@ -827,7 +825,7 @@ Double_t EGammaMvaEleEstimator::IDIsoCombinedMvaValue(Double_t fbrem,
   fMVAVar_spp             = spp;
   fMVAVar_etawidth        = etawidth;
   fMVAVar_phiwidth        = phiwidth;
-  fMVAVar_OneMinusE1x5E5x5= max(min(double(OneMinusE1x5E5x5),2.0),-1.0);
+  fMVAVar_OneMinusE1x5E5x5= std::max(std::min(double(OneMinusE1x5E5x5),2.0),-1.0);
   fMVAVar_R9              = (R9 > 5) ? 5: R9;
 
   fMVAVar_HoE             = HoE;
@@ -868,8 +866,8 @@ Double_t EGammaMvaEleEstimator::IDIsoCombinedMvaValue(Double_t fbrem,
   }
 
   if(printDebug) {
-    cout << " *** Inside the class fMethodname " << fMethodname << endl;
-    cout << " fbrem " <<  fMVAVar_fbrem  
+    std::cout << " *** Inside the class fMethodname " << fMethodname << std::endl;
+    std::cout << " fbrem " <<  fMVAVar_fbrem  
       	 << " kfchi2 " << fMVAVar_kfchi2  
 	 << " mykfhits " << fMVAVar_kfhits  
 	 << " gsfchi2 " << fMVAVar_gsfchi2  
@@ -906,8 +904,8 @@ Double_t EGammaMvaEleEstimator::IDIsoCombinedMvaValue(Double_t fbrem,
          << " NeutralHadronIso_DR0p4To0p5 " <<  NeutralHadronIso_DR0p4To0p5
          << " Rho " <<  Rho
 	 << " eta " << fMVAVar_eta  
-	 << " pt " << fMVAVar_pt << endl;
-    cout << " ### MVA " << mva << endl;
+	 << " pt " << fMVAVar_pt <<std::endl;
+    std::cout << " ### MVA " << mva << std::endl;
   }
 
   return mva;
@@ -965,27 +963,27 @@ Double_t EGammaMvaEleEstimator::isoMvaValue(Double_t Pt,
   Double_t mva = fTMVAReader[bin]->EvaluateMVA(fTMVAMethod[bin]);
 
   if(printDebug) {
-    cout << " *** Inside the class fMethodname " << fMethodname << " fMVAType " << fMVAType << endl;
-    cout  << "ChargedIso ( 0.0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 ): " 
+   std::cout << " *** Inside the class fMethodname " << fMethodname << " fMVAType " << fMVAType << std::endl;
+   std::cout  << "ChargedIso ( 0.0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 ): " 
           << fMVAVar_ChargedIso_DR0p0To0p1   << " "
           << fMVAVar_ChargedIso_DR0p1To0p2   << " "
           << fMVAVar_ChargedIso_DR0p2To0p3 << " "
           << fMVAVar_ChargedIso_DR0p3To0p4 << " "
-          << fMVAVar_ChargedIso_DR0p4To0p5 << endl;
-    cout  << "PF Gamma Iso ( 0.0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 ): " 
+          << fMVAVar_ChargedIso_DR0p4To0p5 <<std::endl;
+   std::cout  << "PF Gamma Iso ( 0.0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 ): " 
           << fMVAVar_GammaIso_DR0p0To0p1 << " "
           << fMVAVar_GammaIso_DR0p1To0p2 << " "
           << fMVAVar_GammaIso_DR0p2To0p3 << " "
           << fMVAVar_GammaIso_DR0p3To0p4 << " "
-          << fMVAVar_GammaIso_DR0p4To0p5 << endl;
-    cout  << "PF Neutral Hadron Iso ( 0.0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 ): " 
+          << fMVAVar_GammaIso_DR0p4To0p5 <<std::endl;
+   std::cout  << "PF Neutral Hadron Iso ( 0.0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 ): " 
           << fMVAVar_NeutralHadronIso_DR0p0To0p1 << " "
           << fMVAVar_NeutralHadronIso_DR0p1To0p2 << " "
           << fMVAVar_NeutralHadronIso_DR0p2To0p3 << " "
           << fMVAVar_NeutralHadronIso_DR0p3To0p4 << " "
           << fMVAVar_NeutralHadronIso_DR0p4To0p5 << " "
-          << endl;
-    cout << " ### MVA " << mva << endl;
+          <<std::endl;
+   std::cout << " ### MVA " << mva <<std::endl;
   }
 
   return mva;
@@ -1008,7 +1006,7 @@ Double_t EGammaMvaEleEstimator::mvaValue(const reco::GsfElectron& ele,
   }
 
   if ( (fMVAType != EGammaMvaEleEstimator::kTrig) && (fMVAType != EGammaMvaEleEstimator::kNonTrig )) {
-    std::cout << "Error: This method should be called for kTrig or kNonTrig MVA only" << endl;
+    std::cout << "Error: This method should be called for kTrig or kNonTrig MVA only" <<std::endl;
     return -9999;
   }
   
@@ -1098,8 +1096,8 @@ Double_t EGammaMvaEleEstimator::mvaValue(const reco::GsfElectron& ele,
 
 
   if(printDebug) {
-    cout << " *** Inside the class fMethodname " << fMethodname << " fMVAType " << fMVAType << endl;
-    cout << " fbrem " <<  fMVAVar_fbrem  
+   std::cout << " *** Inside the class fMethodname " << fMethodname << " fMVAType " << fMVAType <<std::endl;
+   std::cout << " fbrem " <<  fMVAVar_fbrem  
       	 << " kfchi2 " << fMVAVar_kfchi2  
 	 << " mykfhits " << fMVAVar_kfhits  
 	 << " gsfchi2 " << fMVAVar_gsfchi2  
@@ -1119,8 +1117,8 @@ Double_t EGammaMvaEleEstimator::mvaValue(const reco::GsfElectron& ele,
 	 << " d0 " << fMVAVar_d0  
 	 << " ip3d " << fMVAVar_ip3d  
 	 << " eta " << fMVAVar_eta  
-	 << " pt " << fMVAVar_pt << endl;
-    cout << " ### MVA " << mva << endl;
+	 << " pt " << fMVAVar_pt <<std::endl;
+   std::cout << " ### MVA " << mva <<std::endl;
   }
 
 
@@ -1143,7 +1141,7 @@ Double_t EGammaMvaEleEstimator::mvaValue(const reco::GsfElectron& ele,
   }
   
   if (fMVAType != EGammaMvaEleEstimator::kTrigNoIP) {
-    std::cout << "Error: This method should be called for kTrigNoIP MVA only" << endl;
+    std::cout << "Error: This method should be called for kTrigNoIP MVA only" <<std::endl;
     return -9999;
   }
 
@@ -1208,8 +1206,8 @@ Double_t EGammaMvaEleEstimator::mvaValue(const reco::GsfElectron& ele,
 
 
   if(printDebug) {
-    cout << " *** Inside the class fMethodname " << fMethodname << " fMVAType " << fMVAType << endl;
-    cout << " fbrem " <<  fMVAVar_fbrem  
+   std::cout << " *** Inside the class fMethodname " << fMethodname << " fMVAType " << fMVAType <<std::endl;
+   std::cout << " fbrem " <<  fMVAVar_fbrem  
       	 << " kfchi2 " << fMVAVar_kfchi2  
 	 << " mykfhits " << fMVAVar_kfhits  
 	 << " gsfchi2 " << fMVAVar_gsfchi2  
@@ -1231,8 +1229,8 @@ Double_t EGammaMvaEleEstimator::mvaValue(const reco::GsfElectron& ele,
 	 << " rho " << fMVAVar_rho
       // << " EoPout " << fMVAVar_EoPout  
 	 << " eta " << fMVAVar_eta  
-	 << " pt " << fMVAVar_pt << endl;
-    cout << " ### MVA " << mva << endl;
+	 << " pt " << fMVAVar_pt <<std::endl;
+   std::cout << " ### MVA " << mva <<std::endl;
   }
 
 
@@ -1333,8 +1331,8 @@ Double_t EGammaMvaEleEstimator::mvaValue(const pat::Electron& ele,
   }
 
   if(printDebug) {
-    cout << " *** Inside the class fMethodname " << fMethodname << " fMVAType " << fMVAType << endl;
-    cout << " fbrem " <<  fMVAVar_fbrem
+   std::cout << " *** Inside the class fMethodname " << fMethodname << " fMVAType " << fMVAType <<std::endl;
+   std::cout << " fbrem " <<  fMVAVar_fbrem
          << " kfchi2 " << fMVAVar_kfchi2
          << " mykfhits " << fMVAVar_kfhits
          << " gsfchi2 " << fMVAVar_gsfchi2
@@ -1358,8 +1356,8 @@ Double_t EGammaMvaEleEstimator::mvaValue(const pat::Electron& ele,
          << " d0 " << fMVAVar_d0
          << " ip3d " << fMVAVar_ip3d
          << " eta " << fMVAVar_eta
-         << " pt " << fMVAVar_pt << endl;
-    cout << " ### MVA " << mva << endl;
+         << " pt " << fMVAVar_pt <<std::endl;
+   std::cout << " ### MVA " << mva <<std::endl;
   }
 
   return mva;
@@ -1377,7 +1375,7 @@ Double_t EGammaMvaEleEstimator::mvaValue(const pat::Electron& ele,
   }
 
   if ( (fMVAType != EGammaMvaEleEstimator::kTrigNoIP) ) {
-    std::cout << "Error: This method should be called for kTrigNoIP mva only" << endl;
+    std::cout << "Error: This method should be called for kTrigNoIP mva only" <<std::endl;
     return -9999;
   }
   
@@ -1440,8 +1438,8 @@ Double_t EGammaMvaEleEstimator::mvaValue(const pat::Electron& ele,
 
 
   if(printDebug) {
-    cout << " *** Inside the class fMethodname " << fMethodname << " fMVAType " << fMVAType << endl;
-    cout << " fbrem " <<  fMVAVar_fbrem  
+   std::cout << " *** Inside the class fMethodname " << fMethodname << " fMVAType " << fMVAType <<std::endl;
+   std::cout << " fbrem " <<  fMVAVar_fbrem  
       	 << " kfchi2 " << fMVAVar_kfchi2  
 	 << " mykfhits " << fMVAVar_kfhits  
 	 << " gsfchi2 " << fMVAVar_gsfchi2  
@@ -1463,8 +1461,8 @@ Double_t EGammaMvaEleEstimator::mvaValue(const pat::Electron& ele,
 	 << " rho " << fMVAVar_rho
       // << " EoPout " << fMVAVar_EoPout  
 	 << " eta " << fMVAVar_eta  
-	 << " pt " << fMVAVar_pt << endl;
-    cout << " ### MVA " << mva << endl;
+	 << " pt " << fMVAVar_pt <<std::endl;
+   std::cout << " ### MVA " << mva <<std::endl;
   }
 
 
@@ -1634,7 +1632,7 @@ Double_t EGammaMvaEleEstimator::isoMvaValue(const reco::GsfElectron& ele,
   fMVAVar_NeutralHadronIso_DR0p4To0p5 = TMath::Max(TMath::Min((tmpNeutralHadronIso_DR0p4To0p5 - Rho*ElectronEffectiveArea::GetElectronEffectiveArea(ElectronEffectiveArea::kEleNeutralHadronIsoDR0p4To0p5, fMVAVar_eta, EATarget))/ele.pt(), 2.5), 0.0);
  
   if (printDebug) {
-    cout << "UseBinnedVersion=" << fUseBinnedVersion << " -> BIN: " << fMVAVar_eta << " " << fMVAVar_pt << " : " << GetMVABin(fMVAVar_eta,fMVAVar_pt) << endl;
+   std::cout << "UseBinnedVersion=" << fUseBinnedVersion << " -> BIN: " << fMVAVar_eta << " " << fMVAVar_pt << " : " << GetMVABin(fMVAVar_eta,fMVAVar_pt) <<std::endl;
   }
 
   // evaluate
@@ -1651,27 +1649,27 @@ Double_t EGammaMvaEleEstimator::isoMvaValue(const reco::GsfElectron& ele,
 
 
   if(printDebug) {
-    cout << " *** Inside the class fMethodname " << fMethodname << " fMVAType " << fMVAType << endl;
-    cout  << "ChargedIso ( 0.0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 ): " 
+   std::cout << " *** Inside the class fMethodname " << fMethodname << " fMVAType " << fMVAType <<std::endl;
+   std::cout  << "ChargedIso ( 0.0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 ): " 
           << fMVAVar_ChargedIso_DR0p0To0p1   << " "
           << fMVAVar_ChargedIso_DR0p1To0p2   << " "
           << fMVAVar_ChargedIso_DR0p2To0p3 << " "
           << fMVAVar_ChargedIso_DR0p3To0p4 << " "
-          << fMVAVar_ChargedIso_DR0p4To0p5 << endl;
-    cout  << "PF Gamma Iso ( 0.0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 ): " 
+          << fMVAVar_ChargedIso_DR0p4To0p5 <<std::endl;
+   std::cout  << "PF Gamma Iso ( 0.0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 ): " 
           << fMVAVar_GammaIso_DR0p0To0p1 << " "
           << fMVAVar_GammaIso_DR0p1To0p2 << " "
           << fMVAVar_GammaIso_DR0p2To0p3 << " "
           << fMVAVar_GammaIso_DR0p3To0p4 << " "
-          << fMVAVar_GammaIso_DR0p4To0p5 << endl;
-    cout  << "PF Neutral Hadron Iso ( 0.0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 ): " 
+          << fMVAVar_GammaIso_DR0p4To0p5 <<std::endl;
+   std::cout  << "PF Neutral Hadron Iso ( 0.0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 ): " 
           << fMVAVar_NeutralHadronIso_DR0p0To0p1 << " "
           << fMVAVar_NeutralHadronIso_DR0p1To0p2 << " "
           << fMVAVar_NeutralHadronIso_DR0p2To0p3 << " "
           << fMVAVar_NeutralHadronIso_DR0p3To0p4 << " "
           << fMVAVar_NeutralHadronIso_DR0p4To0p5 << " "
-          << endl;
-    cout << " ### MVA " << mva << endl;
+          <<std::endl;
+   std::cout << " ### MVA " << mva <<std::endl;
   }
   
 
@@ -1725,7 +1723,7 @@ Double_t EGammaMvaEleEstimator::IDIsoCombinedMvaValue(const reco::GsfElectron& e
   fMVAVar_etawidth        =  ele.superCluster()->etaWidth();
   fMVAVar_phiwidth        =  ele.superCluster()->phiWidth();
   fMVAVar_OneMinusE1x5E5x5        =  (ele.e5x5()) !=0. ? 1.-(ele.e1x5()/ele.e5x5()) : -1. ;
-  fMVAVar_OneMinusE1x5E5x5 = max(min(double(fMVAVar_OneMinusE1x5E5x5),2.0),-1.0);
+  fMVAVar_OneMinusE1x5E5x5 = std::max(std::min(double(fMVAVar_OneMinusE1x5E5x5),2.0),-1.0);
   fMVAVar_R9              =  myEcalCluster.e3x3(*(ele.superCluster()->seed())) / ele.superCluster()->rawEnergy();
   if (fMVAVar_R9 > 5) fMVAVar_R9 = 5;
 
@@ -1874,7 +1872,7 @@ Double_t EGammaMvaEleEstimator::IDIsoCombinedMvaValue(const reco::GsfElectron& e
     fMVAVar_NeutralHadronIso_DR0p4To0p5 = TMath::Max(TMath::Min((tmpNeutralHadronIso_DR0p4To0p5)/ele.pt(), 2.5), 0.0);
     fMVAVar_rho = Rho;
   } else {
-    cout << "Warning: Type " << fMVAType << " is not supported.\n";
+   std::cout << "Warning: Type " << fMVAType << " is not supported.\n";
   }
 
   // evaluate
@@ -1889,8 +1887,8 @@ Double_t EGammaMvaEleEstimator::IDIsoCombinedMvaValue(const reco::GsfElectron& e
 
 
   if(printDebug) {
-    cout << " *** Inside the class fMethodname " << fMethodname << " fMVAType " << fMVAType << endl;
-    cout << " fbrem " <<  fMVAVar_fbrem  
+   std::cout << " *** Inside the class fMethodname " << fMethodname << " fMVAType " << fMVAType <<std::endl;
+   std::cout << " fbrem " <<  fMVAVar_fbrem  
       	 << " kfchi2 " << fMVAVar_kfchi2  
 	 << " mykfhits " << fMVAVar_kfhits  
 	 << " gsfchi2 " << fMVAVar_gsfchi2  
@@ -1910,28 +1908,28 @@ Double_t EGammaMvaEleEstimator::IDIsoCombinedMvaValue(const reco::GsfElectron& e
 	 << " d0 " << fMVAVar_d0  
 	 << " ip3d " << fMVAVar_ip3d  
 	 << " eta " << fMVAVar_eta  
-	 << " pt " << fMVAVar_pt << endl;
-    cout  << "ChargedIso ( 0.0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 ): " 
+	 << " pt " << fMVAVar_pt <<std::endl;
+   std::cout  << "ChargedIso ( 0.0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 ): " 
           << fMVAVar_ChargedIso_DR0p0To0p1   << " "
           << fMVAVar_ChargedIso_DR0p1To0p2   << " "
           << fMVAVar_ChargedIso_DR0p2To0p3 << " "
           << fMVAVar_ChargedIso_DR0p3To0p4 << " "
-          << fMVAVar_ChargedIso_DR0p4To0p5 << endl;
-    cout  << "PF Gamma Iso ( 0.0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 ): " 
+          << fMVAVar_ChargedIso_DR0p4To0p5 <<std::endl;
+   std::cout  << "PF Gamma Iso ( 0.0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 ): " 
           << fMVAVar_GammaIso_DR0p0To0p1 << " "
           << fMVAVar_GammaIso_DR0p1To0p2 << " "
           << fMVAVar_GammaIso_DR0p2To0p3 << " "
           << fMVAVar_GammaIso_DR0p3To0p4 << " "
-          << fMVAVar_GammaIso_DR0p4To0p5 << endl;
-    cout  << "PF Neutral Hadron Iso ( 0.0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 ): " 
+          << fMVAVar_GammaIso_DR0p4To0p5 <<std::endl;
+   std::cout  << "PF Neutral Hadron Iso ( 0.0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 ): " 
           << fMVAVar_NeutralHadronIso_DR0p0To0p1 << " "
           << fMVAVar_NeutralHadronIso_DR0p1To0p2 << " "
           << fMVAVar_NeutralHadronIso_DR0p2To0p3 << " "
           << fMVAVar_NeutralHadronIso_DR0p3To0p4 << " "
           << fMVAVar_NeutralHadronIso_DR0p4To0p5 << " "
-          << endl;
-    cout  << "Rho : " << Rho << endl;
-    cout << " ### MVA " << mva << endl;
+          <<std::endl;
+   std::cout  << "Rho : " << Rho <<std::endl;
+   std::cout << " ### MVA " << mva <<std::endl;
   }
 
 

--- a/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimatorCSA14.cc
+++ b/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimatorCSA14.cc
@@ -259,7 +259,7 @@ Double_t EGammaMvaEleEstimatorCSA14::mvaValue(const reco::GsfElectron& ele,
   }
 
   if ( (fMVAType != EGammaMvaEleEstimatorCSA14::kTrig) && (fMVAType != EGammaMvaEleEstimatorCSA14::kNonTrig) && (fMVAType != EGammaMvaEleEstimatorCSA14::kNonTrigPhys14) ) {
-    std::cout << "Error: This method should be called for kTrig or kNonTrig or kNonTrigPhys14 MVA only" << endl;
+    std::cout << "Error: This method should be called for kTrig or kNonTrig or kNonTrigPhys14 MVA only" <<std::endl;
     return -9999;
   }
  
@@ -352,8 +352,8 @@ Double_t EGammaMvaEleEstimatorCSA14::mvaValue(const reco::GsfElectron& ele,
 
 
   if(printDebug) {
-    cout << " *** Inside the class fMethodname " << fMethodname << " fMVAType " << fMVAType << endl;
-    cout << " fbrem " <<  fMVAVar_fbrem  
+   std::cout << " *** Inside the class fMethodname " << fMethodname << " fMVAType " << fMVAType <<std::endl;
+   std::cout << " fbrem " <<  fMVAVar_fbrem  
       	 << " kfchi2 " << fMVAVar_kfchi2  
 	 << " mykfhits " << fMVAVar_kfhits  
 	 << " gsfchi2 " << fMVAVar_gsfchi2  
@@ -373,8 +373,8 @@ Double_t EGammaMvaEleEstimatorCSA14::mvaValue(const reco::GsfElectron& ele,
 	 << " d0 " << fMVAVar_d0  
 	 << " ip3d " << fMVAVar_ip3d  
 	 << " eta " << fMVAVar_eta  
-	 << " pt " << fMVAVar_pt << endl;
-    cout << " ### MVA " << mva << endl;
+	 << " pt " << fMVAVar_pt <<std::endl;
+   std::cout << " ### MVA " << mva <<std::endl;
   }
 
 
@@ -393,7 +393,7 @@ Double_t EGammaMvaEleEstimatorCSA14::mvaValue(const pat::Electron& ele,
     }
     
     if ( (fMVAType != EGammaMvaEleEstimatorCSA14::kTrig) && (fMVAType != EGammaMvaEleEstimatorCSA14::kNonTrig) && (fMVAType != EGammaMvaEleEstimatorCSA14::kNonTrigPhys14) ) {
-        std::cout << "Error: This method should be called for kTrig or kNonTrig or kNonTrigPhys14 MVA only" << endl;
+        std::cout << "Error: This method should be called for kTrig or kNonTrig or kNonTrigPhys14 MVA only" <<std::endl;
         return -9999;
     }
     
@@ -456,8 +456,8 @@ Double_t EGammaMvaEleEstimatorCSA14::mvaValue(const pat::Electron& ele,
     
     
     if(printDebug) {
-        cout << " *** Inside the class fMethodname " << fMethodname << " fMVAType " << fMVAType << endl;
-        cout << " fbrem " <<  fMVAVar_fbrem
+       std::cout << " *** Inside the class fMethodname " << fMethodname << " fMVAType " << fMVAType <<std::endl;
+       std::cout << " fbrem " <<  fMVAVar_fbrem
         << " kfchi2 " << fMVAVar_kfchi2
         << " mykfhits " << fMVAVar_kfhits
         << " gsfchi2 " << fMVAVar_gsfchi2
@@ -475,8 +475,8 @@ Double_t EGammaMvaEleEstimatorCSA14::mvaValue(const pat::Electron& ele,
         << " IoEmIoP " << fMVAVar_IoEmIoP  
         << " eleEoPout " << fMVAVar_eleEoPout  
         << " eta " << fMVAVar_eta
-        << " pt " << fMVAVar_pt << endl;
-        cout << " ### MVA " << mva << endl;
+        << " pt " << fMVAVar_pt <<std::endl;
+       std::cout << " ### MVA " << mva <<std::endl;
     }
     
     

--- a/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimatorCSA14.cc
+++ b/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimatorCSA14.cc
@@ -259,7 +259,7 @@ Double_t EGammaMvaEleEstimatorCSA14::mvaValue(const reco::GsfElectron& ele,
   }
 
   if ( (fMVAType != EGammaMvaEleEstimatorCSA14::kTrig) && (fMVAType != EGammaMvaEleEstimatorCSA14::kNonTrig) && (fMVAType != EGammaMvaEleEstimatorCSA14::kNonTrigPhys14) ) {
-    std::cout << "Error: This method should be called for kTrig or kNonTrig or kNonTrigPhys14 MVA only" << std::endl;
+    std::cout << "Error: This method should be called for kTrig or kNonTrig or kNonTrigPhys14 MVA only" << endl;
     return -9999;
   }
  
@@ -352,8 +352,8 @@ Double_t EGammaMvaEleEstimatorCSA14::mvaValue(const reco::GsfElectron& ele,
 
 
   if(printDebug) {
-    std::cout << " *** Inside the class fMethodname " << fMethodname << " fMVAType " << fMVAType << std::endl;
-    std::cout << " fbrem " <<  fMVAVar_fbrem  
+    cout << " *** Inside the class fMethodname " << fMethodname << " fMVAType " << fMVAType << endl;
+    cout << " fbrem " <<  fMVAVar_fbrem  
       	 << " kfchi2 " << fMVAVar_kfchi2  
 	 << " mykfhits " << fMVAVar_kfhits  
 	 << " gsfchi2 " << fMVAVar_gsfchi2  
@@ -373,8 +373,8 @@ Double_t EGammaMvaEleEstimatorCSA14::mvaValue(const reco::GsfElectron& ele,
 	 << " d0 " << fMVAVar_d0  
 	 << " ip3d " << fMVAVar_ip3d  
 	 << " eta " << fMVAVar_eta  
-	 << " pt " << fMVAVar_pt << std::endl;
-    std::cout << " ### MVA " << mva << std::endl;
+	 << " pt " << fMVAVar_pt << endl;
+    cout << " ### MVA " << mva << endl;
   }
 
 
@@ -393,7 +393,7 @@ Double_t EGammaMvaEleEstimatorCSA14::mvaValue(const pat::Electron& ele,
     }
     
     if ( (fMVAType != EGammaMvaEleEstimatorCSA14::kTrig) && (fMVAType != EGammaMvaEleEstimatorCSA14::kNonTrig) && (fMVAType != EGammaMvaEleEstimatorCSA14::kNonTrigPhys14) ) {
-        std::cout << "Error: This method should be called for kTrig or kNonTrig or kNonTrigPhys14 MVA only" << std::endl;
+        std::cout << "Error: This method should be called for kTrig or kNonTrig or kNonTrigPhys14 MVA only" << endl;
         return -9999;
     }
     
@@ -456,8 +456,8 @@ Double_t EGammaMvaEleEstimatorCSA14::mvaValue(const pat::Electron& ele,
     
     
     if(printDebug) {
-        std::cout << " *** Inside the class fMethodname " << fMethodname << " fMVAType " << fMVAType << std::endl;
-        std::cout << " fbrem " <<  fMVAVar_fbrem
+        cout << " *** Inside the class fMethodname " << fMethodname << " fMVAType " << fMVAType << endl;
+        cout << " fbrem " <<  fMVAVar_fbrem
         << " kfchi2 " << fMVAVar_kfchi2
         << " mykfhits " << fMVAVar_kfhits
         << " gsfchi2 " << fMVAVar_gsfchi2
@@ -475,8 +475,8 @@ Double_t EGammaMvaEleEstimatorCSA14::mvaValue(const pat::Electron& ele,
         << " IoEmIoP " << fMVAVar_IoEmIoP  
         << " eleEoPout " << fMVAVar_eleEoPout  
         << " eta " << fMVAVar_eta
-        << " pt " << fMVAVar_pt << std::endl;
-        std::cout << " ### MVA " << mva << std::endl;
+        << " pt " << fMVAVar_pt << endl;
+        cout << " ### MVA " << mva << endl;
     }
     
     

--- a/EgammaAnalysis/ElectronTools/src/ElectronEnergyCalibrator.cc
+++ b/EgammaAnalysis/ElectronTools/src/ElectronEnergyCalibrator.cc
@@ -19,12 +19,6 @@
 #include <sstream>
 #include <iostream>
 
-using std::string;
-using std::vector;
-using std::ifstream;
-using std::istringstream;
-using std::cout;
-using namespace edm;
 
 void ElectronEnergyCalibrator::init()
 {
@@ -35,7 +29,7 @@ void ElectronEnergyCalibrator::init()
             std::cout << "[ElectronEnergyCalibrator] Initialization in DATA mode" << std::endl;
         }
 
-    	ifstream fin(pathData_.c_str());
+	    std::ifstream fin(pathData_.c_str());
     
     	if (!fin){
     		     throw cms::Exception("Configuration")
@@ -49,9 +43,9 @@ void ElectronEnergyCalibrator::init()
                     << pathData_ << " succesfully opened" << std::endl;
             }
     
-        	string s;
-        	vector<string> selements;
-        	string delimiter = ",";
+	    std::string s;
+	    std::vector<std::string> selements;
+	    std::string delimiter = ",";
         	nCorrValRaw = 0;	
     	
         	while ( !fin.eof() ) 
@@ -88,7 +82,7 @@ void ElectronEnergyCalibrator::init()
         // linearity corrections data
         if(applyLinearityCorrection_) 
         {
-            ifstream finlin(pathLinData_.c_str());
+	  std::ifstream finlin(pathLinData_.c_str());
 
             if (!finlin)
             {
@@ -101,9 +95,9 @@ void ElectronEnergyCalibrator::init()
                     std::cout<<"[ElectronEnergyCalibrator] File with Linearity Corrections "<<pathLinData_<<" succesfully opened"<<std::endl;
                 }
 
-                string s;
-                vector<string> selements;
-                string delimiter = ",";
+                std::string s;
+                std::vector<std::string> selements;
+                std::string delimiter = ",";
                 nLinCorrValRaw = 0;	
 
                 while ( !finlin.eof() ) 
@@ -145,12 +139,12 @@ void ElectronEnergyCalibrator::init()
     }
 }
 
-void ElectronEnergyCalibrator::splitString(const string &fullstr, vector<string> &elements, const string &delimiter)
+void ElectronEnergyCalibrator::splitString(const std::string &fullstr, std::vector<std::string> &elements, const std::string &delimiter)
 {
-	string::size_type lastpos = fullstr.find_first_not_of(delimiter, 0);
-	string::size_type pos     = fullstr.find_first_of(delimiter, lastpos);
+	std::string::size_type lastpos = fullstr.find_first_not_of(delimiter, 0);
+	std::string::size_type pos     = fullstr.find_first_of(delimiter, lastpos);
 	
-	while ( ( string::npos != pos ) || ( string::npos != lastpos ) ) 
+	while ( ( std::string::npos != pos ) || ( std::string::npos != lastpos ) ) 
     {
 	    elements.push_back(fullstr.substr(lastpos, pos-lastpos));
 	    lastpos = fullstr.find_first_not_of(delimiter, pos);
@@ -158,9 +152,9 @@ void ElectronEnergyCalibrator::splitString(const string &fullstr, vector<string>
 	}
 }
 
-double ElectronEnergyCalibrator::stringToDouble(const string &str)
+double ElectronEnergyCalibrator::stringToDouble(const std::string &str)
 {
-	istringstream stm;
+  std::istringstream stm;
 	double val = 0;
 	stm.str(str);
 	stm >> val;

--- a/EgammaAnalysis/ElectronTools/src/ElectronEnergyCalibratorRun2.cc
+++ b/EgammaAnalysis/ElectronTools/src/ElectronEnergyCalibratorRun2.cc
@@ -1,0 +1,82 @@
+#include "EgammaAnalysis/ElectronTools/interface/ElectronEnergyCalibratorRun2.h"
+#include <CLHEP/Random/RandGaussQ.h>
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+ElectronEnergyCalibratorRun2::ElectronEnergyCalibratorRun2(EpCombinationTool &combinator, bool isMC, bool synchronization, 
+							   std::vector<double> smearings, std::vector<double> scales) :
+  epCombinationTool_(&combinator),
+  isMC_(isMC), synchronization_(synchronization),
+  rng_(0),
+  smearings_(smearings),
+  scales_(scales)
+{
+}
+
+ElectronEnergyCalibratorRun2::~ElectronEnergyCalibratorRun2()
+{
+}
+
+void ElectronEnergyCalibratorRun2::initPrivateRng(TRandom *rnd) 
+{
+     rng_ = rnd;   
+}
+
+void ElectronEnergyCalibratorRun2::calibrate(reco::GsfElectron &electron, unsigned int runNumber, edm::StreamID const &id) const
+{
+    SimpleElectron simple(electron, runNumber, isMC_);
+    calibrate(simple, id);
+    simple.writeTo(electron);
+}
+void ElectronEnergyCalibratorRun2::calibrate(SimpleElectron &electron, edm::StreamID const & id) const 
+{
+    assert(isMC_ == electron.isMC());
+    float smear = 0.0, scale = 1.0;
+    float aeta = std::abs(electron.getEta()), r9 = electron.getR9();
+    bool bad = (r9 < 0.94), gold = !bad;
+    // FIXME replace hard-coded numbers below with something dependent on a real payload
+    if      (0.0    <= aeta && aeta < 1.0    && bad ) { smear = smearings_[0]; scale = scales_[0]; }
+    else if (0.0    <= aeta && aeta < 1.0    && gold) { smear = smearings_[1]; scale = scales_[1]; }
+    else if (1.0    <= aeta && aeta < 1.4442 && bad ) { smear = smearings_[2]; scale = scales_[2]; }
+    else if (1.0    <= aeta && aeta < 1.4442 && gold) { smear = smearings_[3]; scale = scales_[3]; }
+    else if (1.566  <= aeta && aeta < 2.0    && bad ) { smear = smearings_[4]; scale = scales_[4]; }
+    else if (1.566  <= aeta && aeta < 2.0    && gold) { smear = smearings_[5]; scale = scales_[5]; }
+    else if (2.0    <= aeta && aeta < 2.5    && bad ) { smear = smearings_[6]; scale = scales_[6]; }
+    else if (2.0    <= aeta && aeta < 2.5    && gold) { smear = smearings_[7]; scale = scales_[7]; }
+    /// use the 1.566-2.0 also for the 1.4442-1.566 area, in the lack of a new correction
+    else if (1.4442 <= aeta && aeta < 1.566  && bad ) { smear = smearings_[8]; scale = scales_[8]; } 
+    else if (1.4442 <= aeta && aeta < 1.566  && gold) { smear = smearings_[9]; scale = scales_[9]; } 
+
+    double newEcalEnergy, newEcalEnergyError;
+    if (isMC_) {
+        double corr = 1.0 + smear * gauss(id);
+        newEcalEnergy      = electron.getNewEnergy() * corr;
+        newEcalEnergyError = std::hypot(electron.getNewEnergyError() * corr, smear * newEcalEnergy);
+    } else {
+        newEcalEnergy      = electron.getNewEnergy() / scale;
+        newEcalEnergyError = std::hypot(electron.getNewEnergyError() / scale, smear * newEcalEnergy);
+    }
+    electron.setNewEnergy(newEcalEnergy); 
+    electron.setNewEnergyError(newEcalEnergyError); 
+    epCombinationTool_->combine(electron);
+}
+
+double ElectronEnergyCalibratorRun2::gauss(edm::StreamID const& id) const 
+{
+    if (synchronization_) return 1.0;
+    if (rng_) {
+        return rng_->Gaus();
+    } else {
+        edm::Service<edm::RandomNumberGenerator> rng;
+        if ( !rng.isAvailable() ) {
+            throw cms::Exception("Configuration")
+                << "XXXXXXX requires the RandomNumberGeneratorService\n"
+                "which is not present in the configuration file.  You must add the service\n"
+                "in the configuration file or remove the modules that require it.";
+        }
+        CLHEP::RandGaussQ gaussDistribution(rng->getEngine(id), 0.0, 1.0);
+        return gaussDistribution.fire();
+    }
+}
+

--- a/EgammaAnalysis/ElectronTools/src/EpCombinationTool.cc
+++ b/EgammaAnalysis/ElectronTools/src/EpCombinationTool.cc
@@ -11,7 +11,7 @@ using namespace std;
 
 /*****************************************************************/
 EpCombinationTool::EpCombinationTool():
-    m_forest(NULL)
+    m_forest(NULL), m_ownForest(false)
 /*****************************************************************/
 {
 }
@@ -22,7 +22,7 @@ EpCombinationTool::EpCombinationTool():
 EpCombinationTool::~EpCombinationTool()
 /*****************************************************************/
 {
-    if(m_forest) delete m_forest;
+    if(m_ownForest) delete m_forest;
 }
 
 
@@ -36,7 +36,9 @@ bool EpCombinationTool::init(const string& regressionFileName, const string& bdt
         cout<<"ERROR: Cannot open regression file "<<regressionFileName<<"\n";
         return false;
     }
+    if(m_ownForest) delete m_forest;
     m_forest = (GBRForest*) regressionFile->Get(bdtName.c_str());
+    m_ownForest = true;
     //regressionFile->GetObject(bdtName.c_str(), m_forest); 
     if(!m_forest)
     {
@@ -48,10 +50,17 @@ bool EpCombinationTool::init(const string& regressionFileName, const string& bdt
     return true;
 }
 
+bool EpCombinationTool::init(const GBRForest *forest) 
+{
+    if(m_ownForest) delete m_forest;
+    m_forest = forest;
+    m_ownForest = false;
+    return true;
+}
 
 
 /*****************************************************************/
-void EpCombinationTool::combine(SimpleElectron & mySimpleElectron)
+void EpCombinationTool::combine(SimpleElectron & mySimpleElectron) const
 /*****************************************************************/
 {
     if(!m_forest)
@@ -82,7 +91,7 @@ void EpCombinationTool::combine(SimpleElectron & mySimpleElectron)
             (energy*momentumError/momentum/momentum));
 
     // fill input variables
-    float* regressionInputs = new float[11];
+    float regressionInputs[11];
     regressionInputs[0]  = energy;
     regressionInputs[1]  = energyRelError;
     regressionInputs[2]  = momentum;
@@ -116,6 +125,4 @@ void EpCombinationTool::combine(SimpleElectron & mySimpleElectron)
         mySimpleElectron.setCombinedMomentum(combinedMomentum);
         mySimpleElectron.setCombinedMomentumError(combinedMomentumError);
     }
-
-    delete[] regressionInputs;
 }

--- a/EgammaAnalysis/ElectronTools/src/EpCombinationTool.cc
+++ b/EgammaAnalysis/ElectronTools/src/EpCombinationTool.cc
@@ -4,10 +4,6 @@
 #include <TSystem.h>
 #include <math.h>
 #include <vector>
-#include <iostream>
-
-using namespace std;
-
 
 /*****************************************************************/
 EpCombinationTool::EpCombinationTool():
@@ -27,13 +23,13 @@ EpCombinationTool::~EpCombinationTool()
 
 
 /*****************************************************************/
-bool EpCombinationTool::init(const string& regressionFileName, const string& bdtName)
+bool EpCombinationTool::init(const std::string& regressionFileName, const std::string& bdtName)
 /*****************************************************************/
 {
     TFile* regressionFile = TFile::Open(regressionFileName.c_str());
     if(!regressionFile)
     {
-        cout<<"ERROR: Cannot open regression file "<<regressionFileName<<"\n";
+      std::cout<<"ERROR: Cannot open regression file "<<regressionFileName<<"\n";
         return false;
     }
     if(m_ownForest) delete m_forest;
@@ -42,7 +38,7 @@ bool EpCombinationTool::init(const string& regressionFileName, const string& bdt
     //regressionFile->GetObject(bdtName.c_str(), m_forest); 
     if(!m_forest)
     {
-        cout<<"ERROR: Cannot find forest "<<bdtName<<" in "<<regressionFileName<<"\n";
+      std::cout<<"ERROR: Cannot find forest "<<bdtName<<" in "<<regressionFileName<<"\n";
         regressionFile->Close();
         return false;
     }
@@ -65,7 +61,7 @@ void EpCombinationTool::combine(SimpleElectron & mySimpleElectron) const
 {
     if(!m_forest)
     {
-        cout<<"ERROR: The combination tool is not initialized\n";
+      std::cout<<"ERROR: The combination tool is not initialized\n";
         return;
     }
 

--- a/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc
+++ b/EgammaAnalysis/ElectronTools/src/PFIsolationEstimator.cc
@@ -2,7 +2,6 @@
 #include "EgammaAnalysis/ElectronTools/interface/PFIsolationEstimator.h"
 #include <cmath>
 #include "DataFormats/Math/interface/deltaR.h"
-using namespace std;
 
 #ifndef STANDALONE
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -20,10 +19,6 @@ using namespace std;
 #include "TrackingTools/IPTools/interface/IPTools.h"
 
 #endif
-
-using namespace reco;
-
-
 
 //--------------------------------------------------------------------------------------------------
 PFIsolationEstimator::PFIsolationEstimator() :
@@ -205,7 +200,7 @@ void PFIsolationEstimator::initializeRings(int iNumberOfRings, float fRingSize){
 float PFIsolationEstimator::fGetIsolation(const reco::PFCandidate * pfCandidate, const reco::PFCandidateCollection* pfParticlesColl,reco::VertexRef vtx, edm::Handle< reco::VertexCollection > vertices) {
  
   fGetIsolationInRings( pfCandidate, pfParticlesColl, vtx, vertices);
-  refSC = SuperClusterRef();
+  refSC = reco::SuperClusterRef();
   fIsolation = fIsolationInRings[0];
   
   return fIsolation;
@@ -213,7 +208,7 @@ float PFIsolationEstimator::fGetIsolation(const reco::PFCandidate * pfCandidate,
 
 
 //--------------------------------------------------------------------------------------------------
-vector<float >  PFIsolationEstimator::fGetIsolationInRings(const reco::PFCandidate * pfCandidate, const reco::PFCandidateCollection* pfParticlesColl,reco::VertexRef vtx, edm::Handle< reco::VertexCollection > vertices) {
+std::vector<float >  PFIsolationEstimator::fGetIsolationInRings(const reco::PFCandidate * pfCandidate, const reco::PFCandidateCollection* pfParticlesColl,reco::VertexRef vtx, edm::Handle< reco::VertexCollection > vertices) {
 
   int isoBin;
 
@@ -289,7 +284,7 @@ float PFIsolationEstimator::fGetIsolation(const reco::Photon * photon, const rec
 
 
 //--------------------------------------------------------------------------------------------------
-vector<float >  PFIsolationEstimator::fGetIsolationInRings(const reco::Photon * photon, const reco::PFCandidateCollection* pfParticlesColl,reco::VertexRef vtx, edm::Handle< reco::VertexCollection > vertices) {
+std::vector<float >  PFIsolationEstimator::fGetIsolationInRings(const reco::Photon * photon, const reco::PFCandidateCollection* pfParticlesColl,reco::VertexRef vtx, edm::Handle< reco::VertexCollection > vertices) {
 
   int isoBin;
   
@@ -394,7 +389,7 @@ float PFIsolationEstimator::fGetIsolation(const reco::GsfElectron * electron, co
 
 
 //--------------------------------------------------------------------------------------------------
-vector<float >  PFIsolationEstimator::fGetIsolationInRings(const reco::GsfElectron * electron, const reco::PFCandidateCollection* pfParticlesColl,reco::VertexRef vtx, edm::Handle< reco::VertexCollection > vertices) {
+std::vector<float >  PFIsolationEstimator::fGetIsolationInRings(const reco::GsfElectron * electron, const reco::PFCandidateCollection* pfParticlesColl,reco::VertexRef vtx, edm::Handle< reco::VertexCollection > vertices) {
 
   int isoBin;
   
@@ -415,7 +410,7 @@ vector<float >  PFIsolationEstimator::fGetIsolationInRings(const reco::GsfElectr
   fVx =  electron->vx();
   fVy =  electron->vy();
   fVz =  electron->vz();
-  iMissHits = electron->gsfTrack()->hitPattern().numberOfHits(HitPattern::MISSING_INNER_HITS);
+  iMissHits = electron->gsfTrack()->hitPattern().numberOfHits(reco::HitPattern::MISSING_INNER_HITS);
   
   //  if(electron->ecalDrivenSeed())
   refSC = electron->superCluster();
@@ -579,7 +574,7 @@ float  PFIsolationEstimator::isChargedParticleVetoed(const reco::PFCandidate* pf
 //-----------------------------------------------------------------------------------------------------
 float  PFIsolationEstimator::isChargedParticleVetoed(const reco::PFCandidate* pfIsoCand,reco::VertexRef vtxMain, edm::Handle< reco::VertexCollection >  vertices  ){
   
-  VertexRef vtx = chargedHadronVertex(vertices,  *pfIsoCand );
+  reco::VertexRef vtx = chargedHadronVertex(vertices,  *pfIsoCand );
   if(vtx.isNull())
     return -999.;
   
@@ -685,7 +680,7 @@ float  PFIsolationEstimator::isChargedParticleVetoed(const reco::PFCandidate* pf
 
 
 //--------------------------------------------------------------------------------------------------
- VertexRef  PFIsolationEstimator::chargedHadronVertex(  edm::Handle< reco::VertexCollection > verticesColl, const reco::PFCandidate& pfcand ){
+reco::VertexRef  PFIsolationEstimator::chargedHadronVertex(  edm::Handle< reco::VertexCollection > verticesColl, const reco::PFCandidate& pfcand ){
 
   //code copied from Florian's PFNoPU class
     
@@ -728,7 +723,7 @@ float  PFIsolationEstimator::isChargedParticleVetoed(const reco::PFCandidate* pf
   if (nFoundVertex>0){
     if (nFoundVertex!=1)
       edm::LogWarning("TrackOnTwoVertex")<<"a track is shared by at least two verteces. Used to be an assert";
-    return  VertexRef( verticesColl, iVertex);
+    return  reco::VertexRef( verticesColl, iVertex);
   }
   // no vertex found with this track. 
 
@@ -750,11 +745,11 @@ float  PFIsolationEstimator::isChargedParticleVetoed(const reco::PFCandidate* pf
     }
 
     if( foundVertex ) 
-      return  VertexRef( verticesColl, iVertex);  
+      return  reco::VertexRef( verticesColl, iVertex);  
   
   }
    
-  return  VertexRef( );
+  return  reco::VertexRef( );
 }
 
 

--- a/EgammaAnalysis/ElectronTools/src/PhotonEnergyCalibratorRun2.cc
+++ b/EgammaAnalysis/ElectronTools/src/PhotonEnergyCalibratorRun2.cc
@@ -1,0 +1,76 @@
+#include "EgammaAnalysis/ElectronTools/interface/PhotonEnergyCalibratorRun2.h"
+#include <CLHEP/Random/RandGaussQ.h>
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+PhotonEnergyCalibratorRun2::PhotonEnergyCalibratorRun2(bool isMC, bool synchronization, 
+						       std::vector<double> smearings, std::vector<double> scales) :
+  isMC_(isMC), synchronization_(synchronization),
+  rng_(0),
+  smearings_(smearings),
+  scales_(scales)
+{}
+
+PhotonEnergyCalibratorRun2::~PhotonEnergyCalibratorRun2()
+{}
+
+void PhotonEnergyCalibratorRun2::initPrivateRng(TRandom *rnd) {
+     rng_ = rnd;   
+}
+
+void PhotonEnergyCalibratorRun2::calibrate(reco::Photon &photon, unsigned int runNumber, edm::StreamID const &id) const {
+  SimplePhoton simple(photon, runNumber, isMC_);
+  calibrate(simple, id);
+  simple.writeTo(photon);
+}
+
+void PhotonEnergyCalibratorRun2::calibrate(SimplePhoton &photon, edm::StreamID const & id) const {
+    assert(isMC_ == photon.isMC());
+    float smear = 0.0, scale = 1.0;
+    float aeta = std::abs(photon.getEta()), r9 = photon.getR9();
+    bool bad = (r9 < 0.94), gold = !bad;
+    // FIXME replace hard-coded numbers below with something dependent on a real payload
+    if      (0.0    <= aeta && aeta < 1.0    && bad ) { smear = smearings_[0]; scale = scales_[0]; }
+    else if (0.0    <= aeta && aeta < 1.0    && gold) { smear = smearings_[1]; scale = scales_[1]; }
+    else if (1.0    <= aeta && aeta < 1.4442 && bad ) { smear = smearings_[2]; scale = scales_[2]; }
+    else if (1.0    <= aeta && aeta < 1.4442 && gold) { smear = smearings_[3]; scale = scales_[3]; }
+    else if (1.566  <= aeta && aeta < 2.0    && bad ) { smear = smearings_[4]; scale = scales_[4]; }
+    else if (1.566  <= aeta && aeta < 2.0    && gold) { smear = smearings_[5]; scale = scales_[5]; }
+    else if (2.0    <= aeta && aeta < 2.5    && bad ) { smear = smearings_[6]; scale = scales_[6]; }
+    else if (2.0    <= aeta && aeta < 2.5    && gold) { smear = smearings_[7]; scale = scales_[7]; }
+    /// use the 1.566-2.0 also for the 1.4442-1.566 area, in the lack of a new correction
+    else if (1.4442 <= aeta && aeta < 1.566  && bad ) { smear = smearings_[8]; scale = scales_[8]; } 
+    else if (1.4442 <= aeta && aeta < 1.566  && gold) { smear = smearings_[9]; scale = scales_[9]; } 
+
+    double newEcalEnergy, newEcalEnergyError;
+    if (isMC_) {
+        double corr = 1.0 + smear * gauss(id);
+        newEcalEnergy      = photon.getNewEnergy() * corr;
+        newEcalEnergyError = std::hypot(photon.getNewEnergyError() * corr, smear * newEcalEnergy);
+    } else {
+        newEcalEnergy      = photon.getNewEnergy() / scale;
+        newEcalEnergyError = std::hypot(photon.getNewEnergyError() / scale, smear * newEcalEnergy);
+    }
+
+    photon.setNewEnergy(newEcalEnergy); 
+    photon.setNewEnergyError(newEcalEnergyError); 
+}
+
+double PhotonEnergyCalibratorRun2::gauss(edm::StreamID const& id) const {
+  if (synchronization_) return 1.0;
+  if (rng_) {
+    return rng_->Gaus();
+  } else {
+    edm::Service<edm::RandomNumberGenerator> rng;
+    if ( !rng.isAvailable() ) {
+      throw cms::Exception("Configuration")
+	<< "XXXXXXX requires the RandomNumberGeneratorService\n"
+	"which is not present in the configuration file.  You must add the service\n"
+	"in the configuration file or remove the modules that require it.";
+    }
+    CLHEP::RandGaussQ gaussDistribution(rng->getEngine(id), 0.0, 1.0);
+    return gaussDistribution.fire();
+  }
+}
+

--- a/EgammaAnalysis/ElectronTools/src/SimpleElectron.cc
+++ b/EgammaAnalysis/ElectronTools/src/SimpleElectron.cc
@@ -1,0 +1,38 @@
+#ifndef SimpleElectron_STANDALONE
+#include "EgammaAnalysis/ElectronTools/interface/SimpleElectron.h"
+SimpleElectron::SimpleElectron(const reco::GsfElectron &in, unsigned int runNumber, bool isMC) :
+        run_(runNumber),
+        eClass_(int(in.classification())), 
+        r9_(in.r9()),
+        scEnergy_(in.superCluster()->rawEnergy() + in.isEB() ? 0 : in.superCluster()->preshowerEnergy()), 
+        scEnergyError_(-999.),  // FIXME???
+        trackMomentum_(in.trackMomentumAtVtx().R()), 
+        trackMomentumError_(in.trackMomentumError()), 
+        regEnergy_(in.correctedEcalEnergy()), 
+        regEnergyError_(in.correctedEcalEnergyError()), 
+        eta_(in.superCluster()->eta()), 
+        isEB_(in.isEB()), 
+        isMC_(isMC), 
+        isEcalDriven_(in.ecalDriven()), 
+        isTrackerDriven_(in.trackerDrivenSeed()), 
+        newEnergy_(regEnergy_), 
+        newEnergyError_(regEnergyError_),
+        combinedMomentum_(in.p4(reco::GsfElectron::P4_COMBINATION).P()), 
+        combinedMomentumError_(in.p4Error(reco::GsfElectron::P4_COMBINATION)),
+        scale_(1.0), smearing_(0.0)
+{
+}
+
+
+void SimpleElectron::writeTo(reco::GsfElectron & out) const 
+{
+    math::XYZTLorentzVector oldMomentum = out.p4();
+    math::XYZTLorentzVector newMomentum = math::XYZTLorentzVector(oldMomentum.x()*getCombinedMomentum()/oldMomentum.t(),
+                                                                  oldMomentum.y()*getCombinedMomentum()/oldMomentum.t(),
+                                                                  oldMomentum.z()*getCombinedMomentum()/oldMomentum.t(),
+                                                                  getCombinedMomentum());
+    out.setCorrectedEcalEnergy(getNewEnergy());
+    out.setCorrectedEcalEnergyError(getNewEnergyError());
+    out.correctMomentum(newMomentum, getTrackerMomentumError(), getCombinedMomentumError());
+}
+#endif

--- a/EgammaAnalysis/ElectronTools/src/SimplePhoton.cc
+++ b/EgammaAnalysis/ElectronTools/src/SimplePhoton.cc
@@ -1,0 +1,23 @@
+#ifndef SimplePhoton_STANDALONE
+#include "EgammaAnalysis/ElectronTools/interface/SimplePhoton.h"
+
+SimplePhoton::SimplePhoton(const reco::Photon &in, unsigned int runNumber, bool isMC) :
+  run_(runNumber),
+  eClass_(-1), 
+  r9_(in.r9()),
+  scEnergy_(in.superCluster()->rawEnergy() + in.isEB() ? 0 : in.superCluster()->preshowerEnergy()), 
+  scEnergyError_(-999.),  // FIXME???
+  regEnergy_(in.getCorrectedEnergy(reco::Photon::P4type::regression2)), 
+  regEnergyError_(in.getCorrectedEnergyError(reco::Photon::P4type::regression2)), 
+  eta_(in.superCluster()->eta()), 
+  isEB_(in.isEB()), 
+  isMC_(isMC), 
+  newEnergy_(regEnergy_), 
+  newEnergyError_(regEnergyError_),
+  scale_(1.0), smearing_(0.0)
+{}
+
+void SimplePhoton::writeTo(reco::Photon & out) const {
+  out.setCorrectedEnergy(reco::Photon::P4type::regression2, getNewEnergy(), getNewEnergyError(), true);     
+}
+#endif

--- a/EgammaAnalysis/ElectronTools/src/classes.h
+++ b/EgammaAnalysis/ElectronTools/src/classes.h
@@ -1,0 +1,11 @@
+#include "EgammaAnalysis/ElectronTools/interface/SimpleElectron.h"
+#include "EgammaAnalysis/ElectronTools/interface/EpCombinationTool.h"
+#include "EgammaAnalysis/ElectronTools/interface/ElectronEnergyCalibratorRun2.h"
+
+namespace {
+  struct dictionary {
+    SimpleElectron fuffaElectron;
+    EpCombinationTool fuffaElectronCombinator;
+    ElectronEnergyCalibratorRun2 fuffaElectronCalibrator;
+  };
+}

--- a/EgammaAnalysis/ElectronTools/src/classes_def.xml
+++ b/EgammaAnalysis/ElectronTools/src/classes_def.xml
@@ -1,0 +1,5 @@
+<lcgdict>
+  <class name="SimpleElectron" transient="true" />
+  <class name="ElectronEnergyCalibratorRun2" transient="true" />
+  <class name="EpCombinationTool" transient="true" />
+</lcgdict>

--- a/EgammaAnalysis/ElectronTools/test/ElectronIDValidationAnalyzer.cc
+++ b/EgammaAnalysis/ElectronTools/test/ElectronIDValidationAnalyzer.cc
@@ -167,8 +167,6 @@ ElectronIDValidationAnalyzer::~ElectronIDValidationAnalyzer()
 void
 ElectronIDValidationAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-   // using namespace edm;
-
    edm::Handle<edm::ValueMap<float> > full5x5sieie;
    edm::Handle<edm::View<reco::GsfElectron> > collection;
    edm::Handle<edm::ValueMap<bool> > id_decisions;

--- a/EgammaAnalysis/ElectronTools/test/ElectronIsoAnalyzer.cc
+++ b/EgammaAnalysis/ElectronTools/test/ElectronIsoAnalyzer.cc
@@ -44,9 +44,7 @@
 // class decleration
 //
 
-using namespace edm;
-using namespace reco;
-using namespace std;
+
 class ElectronIsoAnalyzer : public edm::EDAnalyzer {
    public:
       explicit ElectronIsoAnalyzer(const edm::ParameterSet&);
@@ -59,7 +57,7 @@ class ElectronIsoAnalyzer : public edm::EDAnalyzer {
       virtual void endJob() ;
 
 
-  ParameterSet conf_;
+  edm::ParameterSet conf_;
 
 
   unsigned int ev;
@@ -175,9 +173,9 @@ ElectronIsoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
 
 
 
-  Handle<GsfElectronCollection> theEGammaCollection;
+  edm::Handle<reco::GsfElectronCollection> theEGammaCollection;
   iEvent.getByToken(tokenGsfElectrons_,theEGammaCollection);
-  const GsfElectronCollection theEGamma = *(theEGammaCollection.product());
+  const reco::GsfElectronCollection theEGamma = *(theEGammaCollection.product());
 
   // rho for isolation
   edm::Handle<double> rhoIso_h;
@@ -207,9 +205,9 @@ ElectronIsoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
 
     float eff_area_phnh = ElectronEffectiveArea::GetElectronEffectiveArea(effAreaGammaPlusNeutralHad_, abseta, effAreaTarget_);
 
-    double myRho = max<double>(0.,rhoIso);
+    double myRho = std::max<double>(0.,rhoIso);
 
-    float myPfIsoPuCorr = charged + max<float>(0.f, (photon+neutral) - eff_area_phnh*myRho);
+    float myPfIsoPuCorr = charged + std::max<float>(0.f, (photon+neutral) - eff_area_phnh*myRho);
 
 
     if(verbose_) {
@@ -230,7 +228,7 @@ ElectronIsoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
       neutralBarrel_->Fill(neutral/myElectronRef->pt());
       sumBarrel_->Fill((charged+photon+neutral)/myElectronRef->pt());
       sumCorrBarrel_->Fill(myPfIsoPuCorr/myElectronRef->pt());
-      missHitsBarrel_->Fill(myElectronRef->gsfTrack()->hitPattern().numberOfHits(HitPattern::MISSING_INNER_HITS));
+      missHitsBarrel_->Fill(myElectronRef->gsfTrack()->hitPattern().numberOfHits(reco::HitPattern::MISSING_INNER_HITS));
 
     } else {
       chargedEndcaps_ ->Fill(charged/myElectronRef->pt());
@@ -238,7 +236,7 @@ ElectronIsoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
       neutralEndcaps_->Fill(neutral/myElectronRef->pt());
       sumEndcaps_->Fill((charged+photon+neutral)/myElectronRef->pt());
       sumCorrEndcaps_->Fill(myPfIsoPuCorr/myElectronRef->pt());
-      missHitsEndcap_->Fill(myElectronRef->gsfTrack()->hitPattern().numberOfHits(HitPattern::MISSING_INNER_HITS));
+      missHitsEndcap_->Fill(myElectronRef->gsfTrack()->hitPattern().numberOfHits(reco::HitPattern::MISSING_INNER_HITS));
     }
   }
 
@@ -254,7 +252,7 @@ ElectronIsoAnalyzer::beginJob(const edm::EventSetup&)
 // ------------ method called once each job just after ending the event loop  ------------
 void
 ElectronIsoAnalyzer::endJob() {
-  cout << " endJob:: #events " << ev << endl;
+  std::cout << " endJob:: #events " << ev << std::endl;
 }
 
 //define this as a plug-in

--- a/EgammaAnalysis/ElectronTools/test/ElectronTestAnalyzer.cc
+++ b/EgammaAnalysis/ElectronTools/test/ElectronTestAnalyzer.cc
@@ -63,9 +63,7 @@
 // class decleration
 //
 
-using namespace edm;
-using namespace reco;
-using namespace std;
+
 class ElectronTestAnalyzer : public edm::EDAnalyzer {
 public:
   explicit ElectronTestAnalyzer(const edm::ParameterSet&);
@@ -86,10 +84,10 @@ private:
   
   bool trainTrigPresel(const reco::GsfElectron& ele);
   
-  ParameterSet conf_;
+  edm::ParameterSet conf_;
   
-  edm::EDGetTokenT<GsfElectronCollection> gsfEleToken_;
-  edm::EDGetTokenT<GenParticleCollection> genToken_;
+  edm::EDGetTokenT<reco::GsfElectronCollection> gsfEleToken_;
+  edm::EDGetTokenT<reco::GenParticleCollection> genToken_;
   //edm::EDGetTokenT<edm::HepMCProduct>  mcTruthToken_;
   edm::EDGetTokenT<reco::VertexCollection> vertexToken_;
   //edm::EDGetTokenT<reco::PFCandidateCollection> pfCandToken_;
@@ -177,8 +175,8 @@ private:
 //
 ElectronTestAnalyzer::ElectronTestAnalyzer(const edm::ParameterSet& iConfig):
   conf_(iConfig),
-  gsfEleToken_(consumes<GsfElectronCollection>(edm::InputTag("gsfElectrons"))),
-  genToken_(consumes<GenParticleCollection>(edm::InputTag("genParticles"))),
+  gsfEleToken_(consumes<reco::GsfElectronCollection>(edm::InputTag("gsfElectrons"))),
+  genToken_(consumes<reco::GenParticleCollection>(edm::InputTag("genParticles"))),
   //mcTruthToken_(consumes<edm::HepMCProduct>(edm::InputTag("generator"))),
   vertexToken_(consumes<reco::VertexCollection>(edm::InputTag("offlinePrimaryVertices"))),
   //pfCandToken_(consumes<reco::PFCandidateCollection>(edm::InputTag("particleFlow"))),
@@ -290,18 +288,18 @@ ElectronTestAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 
 	ElectronTestAnalyzer::evaluate_mvas(iEvent, iSetup);
 
-  Handle<GsfElectronCollection> theEGammaCollection;
+	edm::Handle<reco::GsfElectronCollection> theEGammaCollection;
   iEvent.getByToken(gsfEleToken_,theEGammaCollection);
-  const GsfElectronCollection theEGamma = *(theEGammaCollection.product());
+  const reco::GsfElectronCollection theEGamma = *(theEGammaCollection.product());
 
-  Handle<GenParticleCollection> genParticles;
+  edm::Handle<reco::GenParticleCollection> genParticles;
   iEvent.getByToken(genToken_,genParticles);
   //InputTag  mcTruthToken_(string("generator"));
   //edm::Handle<edm::HepMCProduct> pMCTruth;
   //iEvent.getByToken(mcTruthToken_,pMCTruth);
   //const HepMC::GenEvent* genEvent = pMCTruth->GetEvent();
 
-  Handle<reco::VertexCollection> thePrimaryVertexColl;
+  edm::Handle<reco::VertexCollection> thePrimaryVertexColl;
   iEvent.getByToken(vertexToken_,thePrimaryVertexColl);
 
   _Rho=0;
@@ -311,17 +309,17 @@ ElectronTestAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 
 
 
-  Vertex dummy;
-  const Vertex *pv = &dummy;
+  reco::Vertex dummy;
+  const reco::Vertex *pv = &dummy;
   if (thePrimaryVertexColl->size() != 0) {
     pv = &*thePrimaryVertexColl->begin();
   } else { // create a dummy PV
-    Vertex::Error e;
+    reco::Vertex::Error e;
     e(0, 0) = 0.0015 * 0.0015;
     e(1, 1) = 0.0015 * 0.0015;
     e(2, 2) = 15. * 15.;
-    Vertex::Point p(0, 0, 0);
-    dummy = Vertex(p, e, 0, 0, 0);
+    reco::Vertex::Point p(0, 0, 0);
+    dummy = reco::Vertex(p, e, 0, 0, 0);
   }
   EcalClusterLazyTools lazyTools(iEvent, iSetup, reducedEBRecHitCollectionToken_, reducedEERecHitCollectionToken_);
 
@@ -342,7 +340,7 @@ ElectronTestAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 
   for(size_t i(0); i < genParticles->size(); i++)
   {
-    const GenParticle &genPtcl = (*genParticles)[i];
+    const reco::GenParticle &genPtcl = (*genParticles)[i];
     float etamc= genPtcl.eta();
     float phimc= genPtcl.phi();
     float ptmc = genPtcl.pt();
@@ -399,7 +397,7 @@ ElectronTestAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 
 
 	  if(debug)
-	    cout << "************************* New Good Event:: " << ev << " *************************" << endl;
+	    std::cout << "************************* New Good Event:: " << ev << " *************************" << std::endl;
 
 	  // ********************* Triggering electrons
 
@@ -441,7 +439,7 @@ ElectronTestAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 	  h_mva_nonTrig->Fill(mvaNonTrigMthd1);
 
 	  if(debug)
-	    cout << "Non-Triggering:: MyMVA Method-1 " << mvaNonTrigMthd1 << " MyMVA Method-2 " << mvaNonTrigMthd2 <<endl;
+	    std::cout << "Non-Triggering:: MyMVA Method-1 " << mvaNonTrigMthd1 << " MyMVA Method-2 " << mvaNonTrigMthd2 <<std::endl;
 
 	  if(elePresel) {
 	    mvaTrigNonIp = myMVATrigNoIPV0->mvaValue( (theEGamma[j]), *pv, _Rho,/*thebuilder,*/lazyTools, debugMVAclass);
@@ -478,9 +476,9 @@ ElectronTestAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 	  }
 
 	  if(debug)
-	    cout << "Triggering:: ElePreselection " << elePresel
+	    std::cout << "Triggering:: ElePreselection " << elePresel
 		 << " MyMVA Method-1 " << mvaTrigMthd1
-	  << " MyMVA Method-2 " << mvaTrigMthd2 << endl;
+		      << " MyMVA Method-2 " << mvaTrigMthd2 << std::endl;
 	}
       } // End Loop on RECO electrons
     } // End if MC electrons selection
@@ -563,8 +561,8 @@ void ElectronTestAnalyzer::myVar(const reco::GsfElectron& ele,
 
 
   if(printDebug) {
-    cout << " My Local Variables " << endl;
-    cout << " fbrem " <<  myMVAVar_fbrem
+    std::cout << " My Local Variables " << std::endl;
+   std::cout << " fbrem " <<  myMVAVar_fbrem
       	 << " kfchi2 " << myMVAVar_kfchi2
 	 << " mykfhits " << myMVAVar_kfhits
 	 << " gsfchi2 " << myMVAVar_gsfchi2
@@ -588,7 +586,7 @@ void ElectronTestAnalyzer::myVar(const reco::GsfElectron& ele,
 	 << " d0 " << myMVAVar_d0
 	 << " ip3d " << myMVAVar_ip3d
 	 << " eta " << myMVAVar_eta
-	 << " pt " << myMVAVar_pt << endl;
+	     << " pt " << myMVAVar_pt << std::endl;
   }
   return;
 }
@@ -665,7 +663,7 @@ bool ElectronTestAnalyzer::trainTrigPresel(const reco::GsfElectron& ele) {
        ele.dr03TkSumPt()/ele.pt() < 0.2 &&
        ele.dr03EcalRecHitSumEt()/ele.pt() < 0.2 &&
        ele.dr03HcalTowerSumEt()/ele.pt() < 0.2 &&
-       ele.gsfTrack()->hitPattern().numberOfLostHits(HitPattern::MISSING_INNER_HITS) == 0)
+       ele.gsfTrack()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS) == 0)
       myTrigPresel = true;
   }
   else {
@@ -674,7 +672,7 @@ bool ElectronTestAnalyzer::trainTrigPresel(const reco::GsfElectron& ele) {
        ele.dr03TkSumPt()/ele.pt() < 0.2 &&
        ele.dr03EcalRecHitSumEt()/ele.pt() < 0.2 &&
        ele.dr03HcalTowerSumEt()/ele.pt() < 0.2 &&
-       ele.gsfTrack()->hitPattern().numberOfLostHits(HitPattern::MISSING_INNER_HITS) == 0)
+       ele.gsfTrack()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS) == 0)
       myTrigPresel = true;
   }
 
@@ -691,7 +689,7 @@ ElectronTestAnalyzer::beginJob(const edm::EventSetup&)
 // ------------ method called once each job just after ending the event loop  ------------
 void
 ElectronTestAnalyzer::endJob() {
-  cout << " endJob:: #events " << ev << endl;
+ std::cout << " endJob:: #events " << ev <<std::endl;
 }
 
 void
@@ -712,11 +710,11 @@ ElectronTestAnalyzer::evaluate_mvas(const edm::Event& iEvent, const edm::EventSe
 // 	iEvent.getByToken(pfCandToken_, hPfCandProduct);
 //   const reco::PFCandidateCollection &inPfCands = *(hPfCandProduct.product());
 
-  Handle<GsfElectronCollection> theEGammaCollection;
+  edm::Handle<reco::GsfElectronCollection> theEGammaCollection;
   iEvent.getByToken(gsfEleToken_,theEGammaCollection);
-  const GsfElectronCollection inElectrons = *(theEGammaCollection.product());
+  const reco::GsfElectronCollection inElectrons = *(theEGammaCollection.product());
 
-  Handle<reco::MuonCollection> hMuonProduct;
+  edm::Handle<reco::MuonCollection> hMuonProduct;
   iEvent.getByToken(muonToken_, hMuonProduct);
   const reco::MuonCollection inMuons = *(hMuonProduct.product());
 
@@ -784,7 +782,7 @@ ElectronTestAnalyzer::evaluate_mvas(const edm::Event& iEvent, const edm::EventSe
  for (reco::GsfElectronCollection::const_iterator iE = inElectrons.begin();
        iE != inElectrons.end(); ++iE) {
 
-		GsfElectron ele = *iE;
+   reco::GsfElectron ele = *iE;
 
  		double idmva = myMVATrigV0->mvaValue(ele,
 					pvCol->at(0),
@@ -792,7 +790,7 @@ ElectronTestAnalyzer::evaluate_mvas(const edm::Event& iEvent, const edm::EventSe
 					lazyTools);
 
 
-		cout << "idmva = " << idmva << endl;
+		std::cout << "idmva = " << idmva <<std::endl;
 
 	}
 

--- a/EgammaAnalysis/ElectronTools/test/ElectronTestAnalyzer.cc
+++ b/EgammaAnalysis/ElectronTools/test/ElectronTestAnalyzer.cc
@@ -179,7 +179,7 @@ ElectronTestAnalyzer::ElectronTestAnalyzer(const edm::ParameterSet& iConfig):
   conf_(iConfig),
   gsfEleToken_(consumes<GsfElectronCollection>(edm::InputTag("gsfElectrons"))),
   genToken_(consumes<GenParticleCollection>(edm::InputTag("genParticles"))),
-  //mcTruthToken_(consumes<edm::HepMCProduct>(edm::InputTag("VtxSmeared"))),
+  //mcTruthToken_(consumes<edm::HepMCProduct>(edm::InputTag("generator"))),
   vertexToken_(consumes<reco::VertexCollection>(edm::InputTag("offlinePrimaryVertices"))),
   //pfCandToken_(consumes<reco::PFCandidateCollection>(edm::InputTag("particleFlow"))),
   eventrhoToken_(consumes<double>(edm::InputTag("kt6PFJets", "rho"))),
@@ -296,7 +296,7 @@ ElectronTestAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 
   Handle<GenParticleCollection> genParticles;
   iEvent.getByToken(genToken_,genParticles);
-  //InputTag  mcTruthToken_(string("VtxSmeared"));
+  //InputTag  mcTruthToken_(string("generator"));
   //edm::Handle<edm::HepMCProduct> pMCTruth;
   //iEvent.getByToken(mcTruthToken_,pMCTruth);
   //const HepMC::GenEvent* genEvent = pMCTruth->GetEvent();

--- a/EgammaAnalysis/ElectronTools/test/MiniAODElectronIDValidationAnalyzer.cc
+++ b/EgammaAnalysis/ElectronTools/test/MiniAODElectronIDValidationAnalyzer.cc
@@ -177,7 +177,6 @@ MiniAODElectronIDValidationAnalyzer::~MiniAODElectronIDValidationAnalyzer()
 void
 MiniAODElectronIDValidationAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-   // using namespace edm;
 
   //edm::Handle<edm::ValueMap<float> > full5x5sieie;
   edm::Handle<edm::View<pat::Electron> > collection;

--- a/EgammaAnalysis/ElectronTools/test/getGBRForest_cfg.py
+++ b/EgammaAnalysis/ElectronTools/test/getGBRForest_cfg.py
@@ -1,0 +1,37 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('GETGBR')
+
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring('/store/data/Run2015D/DoubleEG/MINIAOD/PromptReco-v4/000/258/159/00000/027612B0-306C-E511-BD47-02163E014496.root'),
+)
+
+from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '74X_dataRun2_Prompt_v4', '')
+
+process.getGBR25ns = cms.EDAnalyzer("GBRForestGetterFromDB",
+    grbForestName = cms.string("gedelectron_p4combination_25ns"),
+    outputFileName = cms.untracked.string("GBRForest_data_25ns.root"),
+)
+    
+process.getGBR50ns = cms.EDAnalyzer("GBRForestGetterFromDB",
+    grbForestName = cms.string("gedelectron_p4combination_50ns"),
+    outputFileName = cms.untracked.string("GBRForest_data_50ns.root"),
+)
+
+process.path = cms.Path(
+    process.getGBR25ns +
+    process.getGBR50ns
+)

--- a/EgammaAnalysis/ElectronTools/test/testCalibratedPatElectronProducerRun2_cfg.py
+++ b/EgammaAnalysis/ElectronTools/test/testCalibratedPatElectronProducerRun2_cfg.py
@@ -1,0 +1,86 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('GETGBR')
+
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
+process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
+        calibratedPatElectrons = cms.PSet(
+        initialSeed = cms.untracked.uint32(1),
+        engineName = cms.untracked.string('TRandom3')
+        ),
+        calibratedElectrons = cms.PSet(
+        initialSeed = cms.untracked.uint32(1),
+        engineName = cms.untracked.string('TRandom3')
+        ),
+                                                   )
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+                            fileNames = cms.untracked.vstring(
+        #'/store/data/Run2015D/DoubleEG/MINIAOD/PromptReco-v4/000/258/159/00000/027612B0-306C-E511-BD47-02163E014496.root',
+        #'/store/data/Run2015D/DoubleEG/MINIAOD/PromptReco-v4/000/258/159/00000/06D4AACE-306C-E511-8E3B-02163E011FE7.root',
+        #'/store/data/Run2015D/DoubleEG/MINIAOD/PromptReco-v4/000/258/159/00000/0CB85859-316C-E511-8139-02163E01299C.root',
+        #'/store/data/Run2015D/DoubleEG/MINIAOD/PromptReco-v4/000/258/159/00000/34346FDB-306C-E511-9A4C-02163E013641.root',
+        #'/store/data/Run2015D/DoubleEG/MINIAOD/PromptReco-v4/000/258/159/00000/366AFECD-306C-E511-B475-02163E01358D.root',
+        #'/store/data/Run2015D/DoubleEG/MINIAOD/PromptReco-v4/000/258/159/00000/483AA3A6-306C-E511-A5F2-02163E01437B.root',
+        #'/store/data/Run2015D/DoubleEG/MINIAOD/PromptReco-v4/000/258/159/00000/4E0ED931-316C-E511-9F15-02163E014186.root',
+        '/store/mc/RunIISpring15MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/60000/FE69D710-7E6D-E511-A2F0-008CFA197FAC.root',
+        '/store/mc/RunIISpring15MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/60000/FC529DE1-736D-E511-9386-008CFA1CB8A8.root',
+        '/store/mc/RunIISpring15MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/60000/F8F8A7A4-726D-E511-A351-008CFA166008.root'
+                            )
+)
+
+from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
+#process.GlobalTag = GlobalTag(process.GlobalTag, '74X_dataRun2_Prompt_v4', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '74X_mcRun2_asymptotic_v2', '')
+
+process.selectedElectrons = cms.EDFilter("PATElectronSelector",
+                                         src = cms.InputTag("slimmedElectrons"),
+                                         cut = cms.string("pt > 8 && ((abs(eta)<1.479 && pfIsolationVariables().sumChargedHadronPt/pt < 0.1 && abs(deltaEtaSuperClusterTrackAtVtx)<0.0126 && abs(deltaPhiSuperClusterTrackAtVtx)<0.107 && hcalOverEcal<0.186 && passConversionVeto && pfIsolationVariables().sumNeutralHadronEt/pt < 0.1 && pfIsolationVariables().sumPhotonEt/pt < 0.1 && full5x5_sigmaIetaIeta<0.012) || (abs(eta)>1.479 && pfIsolationVariables().sumChargedHadronPt/pt < 0.1 && abs(deltaEtaSuperClusterTrackAtVtx)<0.0109 && abs(deltaPhiSuperClusterTrackAtVtx)<0.217 && hcalOverEcal<0.09 && passConversionVeto && pfIsolationVariables().sumNeutralHadronEt/pt < 0.1 && pfIsolationVariables().sumPhotonEt/pt < 0.1 && full5x5_sigmaIetaIeta<0.034))")
+)
+
+process.load('EgammaAnalysis.ElectronTools.calibratedElectronsRun2_cfi')
+process.calibratedPatElectrons.electrons = "selectedElectrons"
+process.calibratedPatElectrons.isMC = True
+
+process.zeeUncalib = cms.EDProducer("CandViewShallowCloneCombiner",
+                                    decay = cms.string("selectedElectrons@+ selectedElectrons@-"),
+                                    cut   = cms.string("min(daughter(0).pt,daughter(1).pt) > 15 && mass > 50"),
+                                    )
+
+process.zeeCalib = process.zeeUncalib.clone(
+    decay = cms.string("calibratedPatElectrons@+ calibratedPatElectrons@-"),
+    )
+
+process.zeeUncalibTree = cms.EDFilter("ProbeTreeProducer",
+                                      src = cms.InputTag("zeeUncalib"),
+                                      variables = cms.PSet(
+        mass = cms.string("mass"),
+        massErr = cms.string("0.5 * mass * sqrt( pow( daughter(0).masterClone.p4Error('P4_COMBINATION') / daughter(0).masterClone.p4('P4_COMBINATION').P(), 2 ) + "+
+                             "pow( daughter(0).masterClone.p4Error('P4_COMBINATION') / daughter(0).masterClone.p4('P4_COMBINATION').P(), 2 ) ) "),
+        l1pt = cms.string("daughter(0).pt"),
+        l2pt = cms.string("daughter(1).pt"),
+        l1eta = cms.string("daughter(0).eta"),
+        l2eta = cms.string("daughter(1).eta"),
+        ),
+                                      flags = cms.PSet(),
+                                      )
+
+process.zeeCalibTree = process.zeeUncalibTree.clone(
+    src = cms.InputTag("zeeCalib"),
+    )
+
+process.path = cms.Path(process.selectedElectrons + process.calibratedPatElectrons +
+                        process.zeeUncalib + process.zeeUncalibTree +
+                        process.zeeCalib + process.zeeCalibTree
+                        )
+
+process.TFileService = cms.Service("TFileService", fileName = cms.string("plots_mc.root"))

--- a/EgammaAnalysis/ElectronTools/test/testCalibratedPatPhotonProducerRun2_cfg.py
+++ b/EgammaAnalysis/ElectronTools/test/testCalibratedPatPhotonProducerRun2_cfg.py
@@ -1,0 +1,78 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('GETGBR')
+
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+                            fileNames = cms.untracked.vstring('/store/data/Run2015D/DoubleEG/MINIAOD/PromptReco-v4/000/258/159/00000/027612B0-306C-E511-BD47-02163E014496.root'),
+                            )
+
+from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '74X_dataRun2_Prompt_v4', '')
+
+process.selectedPhotons = cms.EDFilter("PATPhotonSelector",
+                                       src = cms.InputTag("slimmedPhotons"),
+                                       cut = cms.string("pt > 8 && chargedHadronIso()/pt < 0.3"),
+                                       )
+
+process.load('EgammaAnalysis.ElectronTools.calibratedPhotonsRun2_cfi')
+process.calibratedPatPhotons.photons = "selectedPhotons"
+
+process.zeeUncalib = cms.EDProducer("CandViewShallowCloneCombiner",
+                                    decay = cms.string("selectedPhotons@+ selectedPhotons@-"),
+                                    checkCharge = cms.bool(False),                                    
+                                    cut   = cms.string("min(daughter(0).pt,daughter(1).pt) > 15 && mass > 50"),
+                                    )
+
+process.zeeCalib = process.zeeUncalib.clone(
+    decay = cms.string("calibratedPatPhotons@+ calibratedPatPhotons@-"),
+    )
+
+process.zeeUncalibTree = cms.EDFilter("ProbeTreeProducer",
+                                      src = cms.InputTag("zeeUncalib"),
+                                      variables = cms.PSet(
+        mass = cms.string("mass"),
+        #        reco::Photon::P4type::regression2
+
+        #0286     float getCorrectedEnergy( P4type type) const;
+        #0287     float getCorrectedEnergyError( P4type type) const ;
+        #massErr = cms.string("0.5 * mass * sqrt( pow( daughter(0).masterClone.getCorrectedEnergyError(3) / daughter(0).masterClone.p4().P(), 2 ) + "+
+        #                     "pow( daughter(0).masterClone.getCorrectedEnergyError(3) / daughter(0).masterClone.p4().P(), 2 ) ) "),
+        l1pt = cms.string("daughter(0).pt"),
+        l2pt = cms.string("daughter(1).pt"),
+        l1eta = cms.string("daughter(0).eta"),
+        l2eta = cms.string("daughter(1).eta"),
+        ),
+                                      flags = cms.PSet(),
+                                      )
+
+process.zeeCalibTree = process.zeeUncalibTree.clone(
+    src = cms.InputTag("zeeCalib"),
+    )
+
+process.path = cms.Path(process.selectedPhotons + process.calibratedPatPhotons +
+                        process.zeeUncalib + process.zeeUncalibTree +
+                        process.zeeCalib + process.zeeCalibTree
+                        )
+
+process.TFileService = cms.Service("TFileService", fileName = cms.string("plots_photons.root"))
+
+
+#process.out = cms.OutputModule("PoolOutputModule",
+#                               outputCommands = cms.untracked.vstring('keep *_*_*_GETGBR'),
+#                               #    fileName = cms.untracked.string('CandidateZ_newEscale.root')
+#                               fileName = cms.untracked.string('testMC.root')
+#                               )
+#
+#process.end = cms.EndPath(process.out)

--- a/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
@@ -7,7 +7,7 @@ from PhysicsTools.Heppy.physicsobjects.Muon import Muon
 from PhysicsTools.HeppyCore.utils.deltar import bestMatch
 from PhysicsTools.Heppy.physicsutils.RochesterCorrections import rochcor
 from PhysicsTools.Heppy.physicsutils.MuScleFitCorrector   import MuScleFitCorr
-from PhysicsTools.Heppy.physicsutils.ElectronCalibrator import EmbeddedElectronCalibrator
+from PhysicsTools.Heppy.physicsutils.ElectronCalibrator import Run2ElectronCalibrator
 #from CMGTools.TTHAnalysis.electronCalibrator import ElectronCalibrator
 import PhysicsTools.HeppyCore.framework.config as cfg
 from PhysicsTools.HeppyCore.utils.deltar import * 
@@ -33,7 +33,13 @@ class LeptonAnalyzer( Analyzer ):
         else:
             self.cfg_ana.doMuScleFitCorrections = False
 	#FIXME: only Embedded works
-        self.electronEnergyCalibrator = EmbeddedElectronCalibrator()
+        if self.cfg_ana.doElectronScaleCorrections:
+            conf = cfg_ana.doElectronScaleCorrections
+            self.electronEnergyCalibrator = Run2ElectronCalibrator(
+                cfg_comp.isMC,
+                conf['GBRForest'],
+                conf['isSync'] if 'isSync' in conf else False,
+            )
 #        if hasattr(cfg_comp,'efficiency'):
 #            self.efficiency= EfficiencyCorrector(cfg_comp.efficiency)
         # Isolation cut

--- a/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/LeptonAnalyzer.py
@@ -36,8 +36,10 @@ class LeptonAnalyzer( Analyzer ):
         if self.cfg_ana.doElectronScaleCorrections:
             conf = cfg_ana.doElectronScaleCorrections
             self.electronEnergyCalibrator = Run2ElectronCalibrator(
-                cfg_comp.isMC,
+                conf['scales']    if 'scales'    in conf else [ 0.99544,0.99882,0.99662,1.0065,0.98633,0.99536,0.97859,0.98567,0.98633, 0.99536 ],
+                conf['smearings'] if 'smearings' in conf else [ 0.013654,0.014142,0.020859,0.017120,0.028083,0.027289,0.031793,0.030831,0.028083, 0.027289 ],
                 conf['GBRForest'],
+                cfg_comp.isMC,
                 conf['isSync'] if 'isSync' in conf else False,
             )
 #        if hasattr(cfg_comp,'efficiency'):

--- a/PhysicsTools/Heppy/python/physicsutils/ElectronCalibrator.py
+++ b/PhysicsTools/Heppy/python/physicsutils/ElectronCalibrator.py
@@ -1,22 +1,20 @@
-from math import *
+import ROOT
+import os.path
+ROOT.gSystem.Load("libEgammaAnalysisElectronTools")
 
-class EmbeddedElectronCalibrator:
-    def __init__(self,label="calib"):
-        self._label = label
-    def correct(self,cmgelectron,dummy):
-        ele = cmgelectron.sourcePtr().get()
-        if not ele.hasUserFloat("p_"+self._label): 
-            raise RuntimeError, "Electron does not have an embedded energy scale correction with label '%s'" % self._label
-        kind_in = ele.candidateP4Kind()
-        p4_in = ele.p4(kind_in)
-        pCalib    = ele.userFloat("p_"+self._label)
-        pErrCalib = ele.userFloat("pError_"+self._label)
-        pKindCalib = ele.userInt("pKind_"+self._label)
-        ecalCalib  = ele.userFloat("ecalEnergy_"+self._label)
-        eErrCalib  = ele.userFloat("ecalEnergyError_"+self._label)
-        ele.setCorrectedEcalEnergy( ecalCalib )
-        ele.setCorrectedEcalEnergyError( eErrCalib )
-        p4_out = p4_in * (pCalib/p4_in.P())
-        ele.setP4(pKindCalib, p4_out, pErrCalib, True)
-        cmgelectron.setP4(p4_out)
+class Run2ElectronCalibrator:
+    def __init__(self,isMC,gbrForest,isSync=False):
+        self.epCombinationTool = ROOT.EpCombinationTool()
+        self.epCombinationTool.init(os.path.expandvars(gbrForest[0]), gbrForest[1]) 
+        self.random = ROOT.TRandom3()
+        self.random.SetSeed(0) # make it really random across different jobs
+        self.electronEnergyCalibratorRun2 = ROOT.ElectronEnergyCalibratorRun2(self.epCombinationTool, isMC, isSync)
+        self.electronEnergyCalibratorRun2.initPrivateRng(self.random)
+ 
+    def correct(self,electron,run):
+        if not electron.validCandidateP4Kind(): return False # these can't be calibrated
+        electron.uncalibratedP4 = electron.p4()
+        electron.uncalibratedP4Error = electron.p4Error(electron.candidateP4Kind())
+        self.electronEnergyCalibratorRun2.calibrate(electron.physObj, int(run))
+        return True
 

--- a/PhysicsTools/Heppy/python/physicsutils/ElectronCalibrator.py
+++ b/PhysicsTools/Heppy/python/physicsutils/ElectronCalibrator.py
@@ -12,7 +12,7 @@ class Run2ElectronCalibrator:
         for s in scales: vscales.push_back(s)
         vsmearings = ROOT.std.vector('double')()
         for s in smearings: vsmearings.push_back(s)
-        self.electronEnergyCalibratorRun2 = ROOT.ElectronEnergyCalibratorRun2(self.epCombinationTool, isMC, isSync, vscales, vsmearings)
+        self.electronEnergyCalibratorRun2 = ROOT.ElectronEnergyCalibratorRun2(self.epCombinationTool, isMC, isSync, vsmearings, vscales)
         self.electronEnergyCalibratorRun2.initPrivateRng(self.random)
  
     def correct(self,electron,run):

--- a/PhysicsTools/Heppy/python/physicsutils/ElectronCalibrator.py
+++ b/PhysicsTools/Heppy/python/physicsutils/ElectronCalibrator.py
@@ -3,12 +3,16 @@ import os.path
 ROOT.gSystem.Load("libEgammaAnalysisElectronTools")
 
 class Run2ElectronCalibrator:
-    def __init__(self,isMC,gbrForest,isSync=False):
+    def __init__(self, scales, smearings, gbrForest, isMC, isSync=False):
         self.epCombinationTool = ROOT.EpCombinationTool()
         self.epCombinationTool.init(os.path.expandvars(gbrForest[0]), gbrForest[1]) 
         self.random = ROOT.TRandom3()
         self.random.SetSeed(0) # make it really random across different jobs
-        self.electronEnergyCalibratorRun2 = ROOT.ElectronEnergyCalibratorRun2(self.epCombinationTool, isMC, isSync)
+        vscales = ROOT.std.vector('double')()
+        for s in scales: vscales.push_back(s)
+        vsmearings = ROOT.std.vector('double')()
+        for s in smearings: vsmearings.push_back(s)
+        self.electronEnergyCalibratorRun2 = ROOT.ElectronEnergyCalibratorRun2(self.epCombinationTool, isMC, isSync, vscales, vsmearings)
         self.electronEnergyCalibratorRun2.initPrivateRng(self.random)
  
     def correct(self,electron,run):


### PR DESCRIPTION
- E/gamma code from @matteosan1 branch in 76X ( https://twiki.cern.ch/twiki/bin/view/CMS/EGMSmearer )
- Interface for Heppy for electrons as per https://github.com/CERN-PH-CMG/cmg-cmssw/pull/608 , rebased to 74X

The default numbers are still those for 74X, the ones for the 76X re-reco will come probably next week, but that's just configuration.

The Heppy part for photons may come later if somebody codes it.

@arizzi @emanueledimarco
