### PR TITLE
Heppy bugfixes from CMG (76X)

### DIFF
--- a/PhysicsTools/Heppy/interface/JetUtils.h
+++ b/PhysicsTools/Heppy/interface/JetUtils.h
@@ -1,0 +1,18 @@
+#ifndef PhysicsTools_Heppy_JetUtils_h
+#define PhysicsTools_Heppy_JetUtils_h
+
+#include "DataFormats/Common/interface/Ptr.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+
+namespace heppy{
+
+  struct JetUtils{
+
+    static const pat::Jet 
+    copyJet(const edm::ProductID& id, const pat::Jet& ijet, unsigned long key);
+
+  };
+};
+
+
+#endif

--- a/PhysicsTools/Heppy/interface/JetUtils.h
+++ b/PhysicsTools/Heppy/interface/JetUtils.h
@@ -9,7 +9,7 @@ namespace heppy{
   struct JetUtils{
 
     static const pat::Jet 
-    copyJet(const edm::ProductID& id, const pat::Jet& ijet, unsigned long key);
+    copyJet(const pat::Jet& ijet);
 
   };
 };

--- a/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
@@ -120,10 +120,11 @@ class JetAnalyzer( Analyzer ):
         ## Read jets, if necessary recalibrate and shift MET
         if self.cfg_ana.copyJetsByValue: 
           import ROOT
-          allJets = map(lambda j:Jet(ROOT.pat.Jet(ROOT.edm.Ptr(ROOT.pat.Jet)(ROOT.edm.ProductID(),j,0))), self.handles['jets'].product()) #copy-by-value is safe if JetAnalyzer is ran more than once
+          #from ROOT.heppy import JetUtils
+          allJets = map(lambda j:Jet(ROOT.heppy.JetUtils.copyJet(ROOT.edm.ProductID(),j,0)), self.handles['jets'].product())  #copy-by-value is safe if JetAnalyzer is ran more than once
         else: 
           allJets = map(Jet, self.handles['jets'].product()) 
-       
+    
         #set dummy MC flavour for all jets in case we want to ntuplize discarded jets later
         for jet in allJets:
             jet.mcFlavour = 0

--- a/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
+++ b/PhysicsTools/Heppy/python/analyzers/objects/JetAnalyzer.py
@@ -121,7 +121,7 @@ class JetAnalyzer( Analyzer ):
         if self.cfg_ana.copyJetsByValue: 
           import ROOT
           #from ROOT.heppy import JetUtils
-          allJets = map(lambda j:Jet(ROOT.heppy.JetUtils.copyJet(ROOT.edm.ProductID(),j,0)), self.handles['jets'].product())  #copy-by-value is safe if JetAnalyzer is ran more than once
+          allJets = map(lambda j:Jet(ROOT.heppy.JetUtils.copyJet(j)), self.handles['jets'].product())  #copy-by-value is safe if JetAnalyzer is ran more than once
         else: 
           allJets = map(Jet, self.handles['jets'].product()) 
     

--- a/PhysicsTools/Heppy/python/physicsobjects/Jet.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Jet.py
@@ -49,6 +49,48 @@ class Jet(PhysicsObject):
         self._leadingTrack = None
         self._leadingTrackSearched = False
 
+    def rawEnergy(self):
+        return (self.p4()*self.rawFactor()).energy()
+
+    # these energy fraction methods need to be redefined here 
+    # because the pat::Jet's currentJECLevel data member cannot be update easily by the calibrator 
+    # and then the C++ methods would be broken when new jet corrections are applied in Heppy
+    def chargedEmEnergyFraction(self):
+        return self.chargedEmEnergy()/self.rawEnergy()
+
+    def chargedHadronEnergyFraction(self):
+        return self.chargedHadronEnergy()/self.rawEnergy()
+
+    def chargedMuEnergyFraction(self):
+        return self.chargedMuEnergy()/self.rawEnergy()
+
+    def electronEnergyFraction(self):
+        return self.electronEnergy()/self.rawEnergy()
+
+    def muonEnergyFraction(self):
+        return self.muonEnergy()/self.rawEnergy()
+
+    def neutralEmEnergyFraction(self):
+        return self.neutralEmEnergy()/self.rawEnergy()
+
+    def neutralHadronEnergyFraction(self):
+        return self.neutralHadronEnergy()/self.rawEnergy()
+
+    def photonEnergyFraction(self):
+        return self.photonEnergy()/self.rawEnergy()
+
+
+    def HFHadronEnergyFraction(self):
+        return self.HFHadronEnergy()/self.rawEnergy()
+
+    def HFEMEnergyFraction(self):
+        return self.HFEMEnergy()/self.rawEnergy()
+
+    def hoEnergyFraction(self):
+        return self.hoEnergy()/self.rawEnergy()
+
+
+
     def jetID(self,name=""):
         if not self.isPFJet():
             raise RuntimeError, "jetID implemented only for PF Jets"

--- a/PhysicsTools/Heppy/python/physicsobjects/Jet.py
+++ b/PhysicsTools/Heppy/python/physicsobjects/Jet.py
@@ -50,7 +50,7 @@ class Jet(PhysicsObject):
         self._leadingTrackSearched = False
 
     def rawEnergy(self):
-        return (self.p4()*self.rawFactor()).energy()
+        return self.energy() * self.rawFactor()
 
     # these energy fraction methods need to be redefined here 
     # because the pat::Jet's currentJECLevel data member cannot be update easily by the calibrator 
@@ -95,7 +95,7 @@ class Jet(PhysicsObject):
         if not self.isPFJet():
             raise RuntimeError, "jetID implemented only for PF Jets"
         eta = abs(self.eta());
-        energy = (self.p4()*self.rawFactor()).energy();
+        energy = self.rawEnergy();
         chf = self.chargedHadronEnergy()/energy;
         nhf = self.neutralHadronEnergy()/energy;
         phf = self.neutralEmEnergy()/energy;

--- a/PhysicsTools/Heppy/src/JetUtils.cc
+++ b/PhysicsTools/Heppy/src/JetUtils.cc
@@ -1,0 +1,14 @@
+#include "PhysicsTools/Heppy/interface/JetUtils.h"
+
+namespace heppy{
+
+  const pat::Jet
+  JetUtils::copyJet(const edm::ProductID& id, const pat::Jet& ijet, unsigned long key) {
+
+    edm::Ptr<pat::Jet> ptrJet(id, &ijet, key);
+    pat::Jet jet(ptrJet);
+    
+    return jet;
+  }
+
+}

--- a/PhysicsTools/Heppy/src/JetUtils.cc
+++ b/PhysicsTools/Heppy/src/JetUtils.cc
@@ -3,9 +3,9 @@
 namespace heppy{
 
   const pat::Jet
-  JetUtils::copyJet(const edm::ProductID& id, const pat::Jet& ijet, unsigned long key) {
+  JetUtils::copyJet(const pat::Jet& ijet) {
 
-    edm::Ptr<pat::Jet> ptrJet(id, &ijet, key);
+    edm::Ptr<pat::Jet> ptrJet(edm::ProductID(), &ijet, 0,0);
     pat::Jet jet(ptrJet);
     
     return jet;

--- a/PhysicsTools/Heppy/src/classes.h
+++ b/PhysicsTools/Heppy/src/classes.h
@@ -11,6 +11,7 @@
 #include "PhysicsTools/Heppy/interface/Hemisphere.h"
 #include "PhysicsTools/Heppy/interface/AlphaT.h"
 #include "PhysicsTools/Heppy/interface/Apc.h"
+#include "PhysicsTools/Heppy/interface/JetUtils.h"
 #include "PhysicsTools/Heppy/interface/Megajet.h"
 #include "PhysicsTools/Heppy/interface/ReclusterJets.h"
 #include "PhysicsTools/Heppy/interface/IsolationComputer.h"
@@ -44,6 +45,7 @@ namespace {
     heppy::Apc apc;
     heppy::Megajet megajet;
     heppy::ReclusterJets reclusterJets(std::vector<float> px, std::vector<float> py, std::vector<float> pz, std::vector<float> E, double ktpower, double rparam);
+    heppy::JetUtils jetUtils;
     //  heppy::SimpleElectron fuffaElectron;
     //  ElectronEnergyCalibrator fuffaElectronCalibrator;
     //  heppy::ElectronEPcombinator fuffaElectronCombinator;

--- a/PhysicsTools/Heppy/src/classes_def.xml
+++ b/PhysicsTools/Heppy/src/classes_def.xml
@@ -15,6 +15,7 @@
   <class name="heppy::Apc" transient="true" />
   <class name="heppy::Megajet" transient="true" />
   <class name="heppy::ReclusterJets"  transient="true"/>
+  <class name="heppy::JetUtils"  transient="true"/>
   <class name="heppy::IsolationComputer"  transient="true"/>
 
   <!--<class name="heppy::SimpleElectron" transient="true" />-->


### PR DESCRIPTION
- workaround for a python memory leak when cloning jets ( https://github.com/CERN-PH-CMG/cmg-cmssw/pull/637 from @mmarionncern)
- overload in python the jet energy fraction methods to work correctly even after re-calibratio of the jet ( https://github.com/CERN-PH-CMG/cmg-cmssw/pull/635 from @mangano)

80X version also coming now

@arizzi 
