### PR TITLE
eventstfile xrootd resilience

### DIFF
--- a/PhysicsTools/HeppyCore/python/framework/eventstfile.py
+++ b/PhysicsTools/HeppyCore/python/framework/eventstfile.py
@@ -22,7 +22,9 @@ class Events(object):
 
     def to(self, iEv):
         '''navigate to event iEv.'''
-        self.tree.GetEntry(iEv)
+        nbytes = self.tree.GetEntry(iEv)
+        if nbytes < 0:
+            raise IOError("Could not read file")
         return self.tree
 
     def __iter__(self):

--- a/PhysicsTools/HeppyCore/python/framework/eventstfile.py
+++ b/PhysicsTools/HeppyCore/python/framework/eventstfile.py
@@ -7,6 +7,8 @@ class Events(object):
     '''Event list from a tree in a root file.
     '''
     def __init__(self, filename, treename, options=None):
+        self.filename = filename
+        self.treename = treename
         self.file = TFile(filename)
         if self.file.IsZombie():
             raise ValueError('file {fnam} does not exist'.format(fnam=filename))
@@ -24,7 +26,9 @@ class Events(object):
         '''navigate to event iEv.'''
         nbytes = self.tree.GetEntry(iEv)
         if nbytes < 0:
-            raise IOError("Could not read file")
+            raise IOError("Could not read event {0} in tree {1}:{2}".format(
+                iEv, self.filename, self.treename
+            ))
         return self.tree
 
     def __iter__(self):


### PR DESCRIPTION
Check if reading TTree entry was successful, throw error in case not. This is needed in case the TFile is read over xrootd, where the reading may fail. In such a case, there is no way to detect an error and the execution would continue with invalid data.