### PR TITLE
fix default service name

### DIFF
--- a/PhysicsTools/Heppy/python/analyzers/core/TreeAnalyzerNumpy.py
+++ b/PhysicsTools/Heppy/python/analyzers/core/TreeAnalyzerNumpy.py
@@ -11,7 +11,7 @@ class TreeAnalyzerNumpy( Analyzer ):
 
     def __init__(self, cfg_ana, cfg_comp, looperName):
         super(TreeAnalyzerNumpy,self).__init__(cfg_ana, cfg_comp, looperName)
-        self.outservicename = getattr(cfg_ana,"outservicename","outputfile")
+        self.outservicename = getattr(cfg_ana,"outservicename","PhysicsTools.HeppyCore.framework.services.tfile.TFileService_outputfile")
         self.treename = getattr(cfg_ana,"treename","tree")
 
 


### PR DESCRIPTION
`TreeAnalyzerNumpy.py` didn't correctly check for the output service after a recent change in heppy, creating empty outputs.