### PR TITLE
Needed to revert JetReCalibrator again due to merge confusions

### DIFF
--- a/PhysicsTools/Heppy/python/physicsutils/JetReCalibrator.py
+++ b/PhysicsTools/Heppy/python/physicsutils/JetReCalibrator.py
@@ -132,9 +132,10 @@ class JetReCalibrator:
         corrector.setRho(rho)
         corr = corrector.getCorrection()
 
-        if not self.JetUncertainty: raise RuntimeError("Jet energy scale uncertainty shifts requested, but not available")
-        self.JetUncertainty.setJetEta(jet.eta())
-        self.JetUncertainty.setJetPt(corr * jet.pt() * jet.rawFactor())
+        JetUncertainty = self.factorizedUncertainties[uncertainty]
+        if not JetUncertainty: raise RuntimeError("Jet energy scale uncertainty shifts requested, but not available")
+        JetUncertainty.setJetEta(jet.eta())
+        JetUncertainty.setJetPt(corr * jet.pt() * jet.rawFactor())
 
         try:
             jet.jetEnergyCorrUncertainty = JetUncertainty.getUncertainty(True)


### PR DESCRIPTION
As discussed with @arizzi in private, looks like the sync from vhbb -> cbernet (https://github.com/cbernet/cmssw/pull/81/files#diff-d7604be297d3e2f40710fe8859b5e778L112) reverted the PR I had made against cbernet (https://github.com/cbernet/cmssw/pull/78), so here we re-revert it for `JetReCalibrator.py`.